### PR TITLE
By default, pecl use the latest most updated version (beta).

### DIFF
--- a/resources/install.sh
+++ b/resources/install.sh
@@ -173,7 +173,7 @@ if [[ -d "/etc/php5/" ]]; then
   apt-get -y install php5-dev
 
   if [[ -d "/etc/php5/cli/" && ! `cat /etc/php5/cli/php.ini | grep "mosquitto"` ]]; then
-    echo "" | pecl install Mosquitto-alpha
+    echo "" | pecl install Mosquitto-beta
     echo "extension=mosquitto.so" | tee -a /etc/php5/cli/php.ini
   fi
 


### PR DESCRIPTION
No stable version is available as of 2018/03/06, pecl will install the latest version,
so we switch from alpha to beta, just to avoid any confusion.

NB: if a beta is available, pecl will install it, even if an alpha was requested.
ie, everyone should have mosquitto-beta already installed (v0.0.40).