### PR TITLE
Surveillance de syslog en cas de crash pl2303

### DIFF
--- a/Documentation/015_Systemes_Testes.asciidoc
+++ b/Documentation/015_Systemes_Testes.asciidoc
@@ -12,10 +12,10 @@ Jeedom fonctionne sur le systeme linux debian, de ce fait ce plugin est dévelop
 
 == Les autres envirronements
 
-Les autres envirronements ne sont pas testés par défaut mais nous vous aiderons dans la mesure du possible.
+Les autres environnements ne sont pas testés par défaut mais nous vous aiderons dans la mesure du possible.
 
 === En retour d'experience sur le forum:
 
-- Windows ne fonctionne pas, car pas Linux
-- Ubuntu fonctionne mais demande de mettre les mains dans le cambouit, l'installation même de Jeedom n'est pas immédiate
+- Windows ne fonctionne pas, car pas Linux (Pas de support Jeedom)
+- Ubuntu fonctionne mais demande de mettre les mains dans le cambouis, l'installation même de Jeedom n'est pas immédiate
 - Odroid/HardKernel devrait fonctionner

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -41,10 +41,17 @@ class Abeille extends eqLogic
         return $return;
     }
 
-    public static function cron5()
+    /**
+     * Look every 15 minutes if the kernel driver is not in error
+     */
+    public static function cron15()
     {
-        $deamon_info = self::deamon_info();
-        if ($deamon_info['state'] != 'ok') {
+        $cmd = "egrep 'pl2303' /var/log/syslog | tail -1 | egrep -c 'failed|stopped'";
+        $output=array();
+        exec(system::getCmdSudo() . $cmd,$output);
+        $usbZigateStatus  = !is_null($output)?(is_numeric($output[0])?$output[0]:'-1'):'-1';
+        if ($usbZigateStatus != '0') {
+            message::add("Abeille", "Erreur, le pilote pl2303 est en erreur, impossible de communiquer avec la zigate. Il faut débrancher/rebrancher la zigate et relancer le demon.");
             return;
         }
     }

--- a/resources/AbeilleDeamon/CmdToAbeille.php
+++ b/resources/AbeilleDeamon/CmdToAbeille.php
@@ -219,7 +219,7 @@
 
 
     /**
-     * Main function called by AbeilleMQTTCmd to process command and send it in binzry to /dev/ttyUSB0
+     * Main function called by AbeilleMQTTCmd to process command and send it in binary to /dev/ttyUSB0
      *
      * @param $dest destination for binary command
      * @param $Command command to send


### PR DESCRIPTION
CF issue #227 

utilisation de la cron15 pour une surveillance pas trop lourde
Envoi d'un message en cas de crash du pilote pl2303 avec la méthode pour remettre en route la zigate.

