### PR TITLE
add default config for onlyTimer mode in Abeille configuration.

### DIFF
--- a/core/config/Abeille.config.ini
+++ b/core/config/Abeille.config.ini
@@ -3,3 +3,4 @@ AbeilleSerialPort = /dev/ttyUSB0
 creationObjectMode = Automatique
 showAllCommands= N
 mqttQos= 0
+onlyTimer= N


### PR DESCRIPTION
Ajout de la configuration par défaut pour le timer (valeur Non) , sinon cela reste vide.