### PR TITLE
Docker: in ARM version, workaround is needed to detect status

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -572,7 +572,6 @@ class Abeille extends eqLogic
         $debug_serviceMosquittoStatus = 0;
 
         $outputSvc = array();
-        $outputStl = array();
         $return = array();
         $return['launchable'] = 'nok';
         $return['launchable_message'] = 'Service not running yet.';
@@ -581,6 +580,12 @@ class Abeille extends eqLogic
         exec(system::getCmdSudo() . $cmdSvc, $outputSvc);
         $logmsg = 'Status du service mosquitto : ' . ($outputSvc[0] > 0 ? 'OK' : 'Probleme') . '   (' . implode($outputSvc, '!') . ')';
         if ( $debug_serviceMosquittoStatus ) log::add('Abeille', 'debug', $logmsg);
+        //Docker workaround as service will not write a pid file for mosquitto (status will always fail)
+        if (file_exists("/.dockerenv")== true ){
+            $outputSvc= array();
+            exec(system::getCmdSudo() . "pgrep mosquitto", $outputSvc);
+            if ( $debug_serviceMosquittoStatus ) log::add('Abeille','debug','docker test: pid of mosquitto: ' . $outputSvc[0]);
+        }
         if ($outputSvc[0] > 0) {
             $return['launchable'] = 'ok';
             $return['launchable_message'] = 'Service mosquitto is running.';


### PR DESCRIPTION
Ajout d'un contournement pour l'execution sous docker arm, le service mosquitto ne crée pas de fichier pid au lancement, de ce fait le status retourné est toujours fail. le test retourne le num du pid.

system status mosquitto is not effective as mosquitto.pid does not exists. It does not exist because of the way it is launched.

https://github.com/schollz/find/issues/140