### PR TITLE
getDeviceNameFromJson filter json file Fix  #624 + php notice fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,13 @@
 
 root = true
 
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+
+
 [*.php]
 charset = utf-8
 end_of_line = lf

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -937,7 +937,7 @@
             //
             log::add('Abeille', 'debug', 'deamon_start_cleanup: Fin des modifications si nécessaire');
 
-            if (restartNeeded == 1) {
+            if ($restartNeeded == 1) {
                 // afficher un message utilisateur pour qu il reboot le bousain.
                 message::add(
                     "Abeille",
@@ -957,7 +957,7 @@
             $parameters_info = self::getParameters();
 
             //no need as it seems to be on cron
-            $deamon_info = self::deamon_info();
+            $deamon_info = self::getDependencyInfo();
             if ($deamon_info['launchable'] != 'ok') {
                 message::add("Abeille", "Vérifier la configuration, un parametre manque");
                 throw new Exception(__('Veuillez vérifier la configuration', __FILE__));

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -707,7 +707,7 @@
                 }
             }
             //deps ok ?
-            $dependancy_info = self::dependancy_info();
+            $dependancy_info = self::getDependencyInfo();
             if ($dependancy_info['state'] == 'ok') {
                 if ($debug_deamon_info) {
                     log::add('Abeille', 'debug', 'deamon_info: les dependances sont Ok');
@@ -1122,12 +1122,13 @@
             message::removeAll('Abeille', 'stopDeamon');
         }
 
-        public static function dependancy_info()
+        public static function getDependencyInfo()
         {
             $debug_dependancy_info = 0;
 
             $return = array();
             $return['state'] = 'nok';
+            $return['launchable'] = 'nok';
             $return['progress_file'] = jeedom::getTmpFolder('Abeille').'/dependance';
             $cmd = "dpkg -l | grep mosquitto";
             exec($cmd, $output_dpkg, $return_var);
@@ -1139,6 +1140,7 @@
 
             if ($output_dpkg[0] != "" && $libphp) {
                 //$return['configuration'] = 'ok';
+                $return['launchable'] = 'ok';
                 $return['state'] = 'ok';
             } else {
                 if ($output_dpkg[0] == "") {

--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -208,7 +208,7 @@ class Tools
         $deviceDir = dirname(__FILE__) . '/../../../core/config/devices/';
         echo 'ddir: ' . $deviceDir;
         if ($dh = opendir($deviceDir)) {
-            while (($file = readdir($dh)) !== false) {
+            while ((($file = readdir($dh)) !== false) && (pathinfo($file,PATHINFO_EXTENSION)=="json")) {
 
                 try {
                     $content = file_get_contents($deviceDir . $file . DIRECTORY_SEPARATOR . $file . '.json');

--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -238,12 +238,11 @@ class Tools
     // en ligne de comande =>
     // "php Tools.class.php 1"
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    
+    $debugBEN = 0;
     if (isset($argv[1])) {
         $debugBEN = $argv[1];
-    } else {
-        $debugBEN = 0;
     }
+
     if ($debugBEN != 0) {
         echo "Debut Tools.php test mode\n";
         $message = new stdClass();
@@ -255,9 +254,5 @@ class Tools
                 break;
         } // switch
     } // if debug
-                                                                   
-                                                                   
-                
-
 
 ?>

--- a/resources/syncconf.sh
+++ b/resources/syncconf.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "Lancement du téléchargement des configurations"
 
 cd /var/www/html/plugins/Abeille/core/config/


### PR DESCRIPTION

fix #624 getDeviceNameFromJson filtre les json et ne traite plus les fichiers php placés dans le repertoire device.

renommage du dependancy_info (fonction obsolete du core) en getDependencyInfo dans l'autre class d'Abeille. il reste des appels a dependancy_info que je n'ai pas trouvé

conversion des CRLF en LF et ajout du she-bang dans syncconf.sh

