### PR TITLE
delete small cases logs levels as parameter is converted to uppercase…

### DIFF
--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -41,14 +41,10 @@ class Tools
                          "ERROR" => 1,
                          "WARNING" => 2,
                          "INFO" => 3,
-                         "DEBUG" => 4,
-                         "none" => 0,
-                         "error" => 1,
-                         "warning" => 2,
-                         "info" => 3,
-                         "debug" => 4,              );
+                         "DEBUG" => 4
+         );
 
-       $upperString = strtoupper($loglevel);
+       $upperString = strtoupper(trim($loglevel));
        if (array_search($upperString,$niveau,false)) {
            return $niveau[$upperString];
             }


### PR DESCRIPTION
… before use.Fix #686

parameter trim to prevent start/end space.