### PR TITLE
Fix pour Jeedom V3 sous Debian Buster / PHP 7.3

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -1786,7 +1786,7 @@
             if ($parameters_info['AbeilleParentId'] > 0) {
                 $elogic->setObject_id($parameters_info['AbeilleParentId']);
             } else {
-                $elogic->setObject_id(object::rootObject()->getId());
+                $elogic->setObject_id(jeeObject::rootObject()->getId());
             }
             $elogic->setEqType_name('Abeille');
             $elogic->setConfiguration('topic', "Abeille/Ruche");
@@ -2237,8 +2237,8 @@
                 break;
                 
             case "10":
-                // $object = object::rootObject()->getId();
-                $object = object::all();
+                // $object = jeeObject::rootObject()->getId();
+                $object = jeeObject::all();
                 print_r($object);
                 break;
                 

--- a/desktop/php/Abeille.php
+++ b/desktop/php/Abeille.php
@@ -565,7 +565,7 @@ td.two {
                                 <select class="eqLogicAttr form-control"            data-l1key="object_id">
                                     <option value="">{{Aucun}}</option>
                                     <?php
-                                    foreach (object::all() as $object) {
+                                    foreach (jeeObject::all() as $object) {
                                         echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
                                     }
                                     ?>

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -87,7 +87,7 @@
                     <div class="col-lg-4">
                         <select class="configKey form-control" data-l1key="AbeilleParentId">
                             <?php
-                                foreach (object::all() as $object) {
+                                foreach (jeeObject::all() as $object) {
                                     echo '<option value="' . $object->getId() . '">' . $object->getName() . '</option>';
                                 }
                             ?>


### PR DESCRIPTION
Passage de object => jeeObject

Les nouvelles installation de jeedom sur RaspberryPi 4 se font avec Debian Buster qui arrivent avec la version PHP 7.3. Hors depuis la version 7.2 de PHP, il est interdit de nommer une classe "object"
Jeedom avait déjà faire le nécéssaire en v3 (object est un alias de jeeObject). Je ne pense pas que ça soit suffisant pour Jeedom v4 mais ça permet de faire tourner la v3 sous Buster.

https://www.php.net/manual/fr/migration72.incompatible.php

Aide à la résolution de : #798 #787 #774 