### PR TITLE
Config page: check TTY enhanced. Checks if port in use

### DIFF
--- a/core/ajax/abeille.ajax.php
+++ b/core/ajax/abeille.ajax.php
@@ -67,13 +67,13 @@ try {
         log::add('AbeillePiZigate', 'debug', 'Arret du démon');
         abeille::deamon_stop(); // Stopping daemon
 
-        /* 'checkTTY' script no longer required.
-           Replaced by 'zg_GetVersion()' */
-        // $cmdToExec = "checkTTY.sh " . $zgPort;
-        // $cmd = '/bin/bash ' . dirname(__FILE__) . '/../../resources/' . $cmdToExec . ' >>' . log::getPathToLog('AbeillePiZigate') . ' 2>&1';
-        // exec($cmd, $out, $status);
-        $status = 0;
+        /* Checks port exists and is not already used */
+        $cmdToExec = "checkTTY.sh " . $zgPort;
+        $cmd = '/bin/bash ' . dirname(__FILE__) . '/../../resources/' . $cmdToExec . ' >>' . log::getPathToLog('AbeillePiZigate') . ' 2>&1';
+        exec($cmd, $out, $status);
+        // $status = 0;
 
+        /* Read Zigate FW version */
         $version = 0; // FW version
         if ($status == 0) {
             $status = zg_GetVersion($zgPort, $version);

--- a/resources/checkTTY.sh
+++ b/resources/checkTTY.sh
@@ -1,6 +1,7 @@
+#! /bin/bash
+
 ###
-### Check if Zigate is responding properly to "Get Version" command.
-### Allows to confirm that port & communication are ok.
+### Check TTY port and proper access to Zigate.
 ### WARNING: This script expects that daemon is stoppped to
 ###          not disturb Zigate answer.
 ###
@@ -12,6 +13,35 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 PORT=$1
+
+echo "Vérifications du port '${PORT}'"
+
+# Port exists ?
+if [ ! -e ${PORT} ]; then
+    echo "= ERREUR: Le port ${PORT} n'existe pas !"
+    exit 2
+fi
+
+# Is port already used ?
+FIELDS=`lsof -Fcn ${PORT}`
+if [ "${FIELDS}" == "" ]; then
+    echo "= Ok, le port semble libre."
+else
+    CMD=""
+    for f in ${FIELDS};
+    do
+        if [[ "$f" != "c"* ]]; then
+            continue
+        fi
+        CMD=${f:1}
+    done
+    echo "= ERREUR: Port utilisé par la commande '${CMD}'."
+    echo "=         Le port doit être libéré pour permettre le dialogue avec la Zigate."
+    exit 3
+fi
+
+# Zigate communication check now done from PHP
+exit 0
 
 # echo "Configuration du port ${PORT}"
 # stty -F ${PORT} 115200 -parity cs8 -cstopb


### PR DESCRIPTION
Une petite amélioration du "check TTY".
Vérifie si le port est déja utilisé et sort en erreur si c'est le cas en indiquant la commande qui l'utilise.

Ex: ttyS0 utilisé par la commande "agetty"