### PR TITLE
Config DB: Added 'AbeilleTypeX' + update at daemon startup

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -22,6 +22,7 @@
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
     include_once dirname(__FILE__).'/AbeilleMsg.php';
+    include_once dirname(__FILE__).'/../../plugin_info/install.php'; // updateConfigDB()
 
     /* Errors reporting: uncomment below lines for debug */
     // error_reporting(E_ALL);
@@ -413,13 +414,11 @@
             return $return;
         }
 
-        /* This function is used to run some cleanup before starting demons,
+        /* This function is used to run some cleanup before starting daemons,
            or update the database due to data needed changes. */
         /* TODO: Move to correct naming 'daemon' and not 'deamon' */
         public static function deamon_start_cleanup($message = null) {
             log::add('Abeille', 'debug', 'deamon_start_cleanup(): Démarrage');
-
-            $debug = 0;
 
             // ******************************************************************************************************************
             // Remove temporary files
@@ -439,6 +438,15 @@
                 config::save( "AbeilleIEEE_Ok".$i, 0, 'Abeille');
             }
 
+            /* Checking configuration DB version.
+               If standard user, this should be done by installation process (install.php).
+               If user based on GIT, this is a work-around */
+            $dbVersion = config::byKey('DbVersion', 'Abeille', '');
+            if (($dbVersion == '') || (intval($dbVersion) < 20200510)) {
+                log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v'.$dbVersion.'. Mise-à-jour nécéssaire.');
+                updateConfigDB();
+            }
+
             log::add('Abeille', 'debug', 'deamon_start_cleanup(): Terminé');
             return;
         }
@@ -449,7 +457,19 @@
 
             log::add('Abeille', 'debug', 'deamon_start(): Démarrage');
 
-            $param = self::getParameters();
+            /* Some checks before starting daemons
+               - Are dependancies ok ?
+               - Is cron running ? */
+            if (self::dependancy_info()['state'] != 'ok') {
+                message::add("Abeille", "Tentative de demarrage alors qu il y a un soucis avec les dependances", "Avez vous installée les dépendances.", 'Abeille/Demon');
+                log::add('Abeille', 'debug', "Tentative de demarrage alors qu il y a un soucis avec les dependances");
+                return false;
+            }
+            if (!is_object(cron::byClassAndFunction('Abeille', 'deamon'))) {
+                log::add('Abeille', 'error', 'deamon_start(): Tache cron introuvable');
+                message::add("Abeille", "deamon_start(): Tache cron introuvable", "Est un bug dans Abeille ?", "Abeille/Demon");
+                throw new Exception(__('Tache cron introuvable', __FILE__));
+            }
 
             self::deamon_stop();
 
@@ -460,17 +480,7 @@
 
             self::deamon_start_cleanup();
 
-            if (self::dependancy_info()['state'] != 'ok') {
-                message::add("Abeille", "Tentative de demarrage alors qu il y a un soucis avec les dependances", "Avez vous installée les dépendances.", 'Abeille/Demon');
-                log::add('Abeille', 'debug', "Tentative de demarrage alors qu il y a un soucis avec les dependances");
-                return false;
-            }
-
-            if (!is_object(cron::byClassAndFunction('Abeille', 'deamon'))) {
-                log::add('Abeille', 'error', 'deamon_start(): Tache cron introuvable');
-                message::add("Abeille", "deamon_start(): Tache cron introuvable", "Est un bug dans Abeille ?", "Abeille/Demon");
-                throw new Exception(__('Tache cron introuvable', __FILE__));
-            }
+            $param = self::getParameters();
 
             /* Configuring GPIO for PiZigate case.
             TODO: Should be done only if PiZigate is present to avoid any unexpected side effect. */


### PR DESCRIPTION
Salut Kiwi.
Voila une update pour préparer le terrain. J'ai ajouté le type de Zigate dans la config (AbeilleTypeX).
Mais + que ca, l'update de la DB se fait si nécessaire au (re)démarrage des démons. Ca manquait pour les developpeurs ou utilisateurs du GIT qui eux ne passent probablement jamais par "install.php".

A suivre... une refonte de la page de config avec le type (entre autre). Je peaufine...

Résumé des changements

install.php
- New: Ajout du param de config 'AbeilleTypeX' pour choisir 'USB', 'WIFI' ou 'PI'.
  Devine le type des zigates déja connues en fonction du port série.
- updateConfigDB() ajoutée. Appelée au démarrage du démon si necessaire

Abeille.class.php
- New: Dans deamon_start_cleanup(), vérifie la date de la DB config et appelle updateConfigDB()
  si trop vieux. Permet de remplacer une installation propre via "install.php".
