### PR TITLE
8011 prelim decode + cosmetic

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -646,14 +646,14 @@
             // Stop socat if exist
             exec("ps -e -o '%p %a' --cols=10000 | awk '/socat /' | awk '/\/dev\/zigate/' | awk '{print $1}' | tr  '\n' ' '", $output);
             log::add('Abeille', 'debug', 'deamon_stop(): Killing deamons socat: '.implode($output, '!'));
-            system::kill($output, true);
+            system::kill(implode($output, ' '), true);
             exec(system::getCmdSudo()."kill -15 ".implode($output, ' ')." 2>&1");
             exec(system::getCmdSudo()."kill -9 ".implode($output, ' ')." 2>&1");
 
             // Stop other deamon
             exec("ps -e -o '%p %a' --cols=10000 | awk '/Abeille(Parser|SerialRead|Cmd|Socat|Interrogate).php /' | awk '{print $1}' | tr  '\n' ' '", $output);
             log::add('Abeille', 'debug', 'deamon stop: Killing deamons: '.implode($output, '!'));
-            system::kill($output, true);
+            system::kill(implode($output, ' '), true);
             exec(system::getCmdSudo()."kill -15 ".implode($output, ' ')." 2>&1");
             exec(system::getCmdSudo()."kill -9 ".implode($output, ' ')." 2>&1");
 


### PR DESCRIPTION
Une p'tite update sans gros changement fonctionnel.

AbeilleParser
- Cosmetic: messages de debug
- 8011: Décodage préliminaire mais inutilisé.
- Cosmetic: displayStatus(), message zigbee err code aligné avec les autres (<code>-<mess>)
- Cosmetic: Message info "ZigateX en mode INCLUSION" et "ZigateX: FIN du mode inclusion"
- Indentation: remplacement qq tabs vers space.

Abeille.class.php
- Fixe: pour virer l'erreur PHP suivante

PHP Warning:  trim() expects parameter 1 to be string, array given in /var/www/html/core/class/system.class.php on line 139
    PHP Stack trace:
    PHP   1. {main}() /var/www/html/plugins/Abeille/core/ajax/abeille.ajax.php:0
    PHP   2. Abeille::deamon_start() /var/www/html/plugins/Abeille/core/ajax/abeille.ajax.php:110
    PHP   3. Abeille::deamon_stop() /var/www/html/plugins/Abeille/core/class/Abeille.class.php:474
    PHP   4. system::kill() /var/www/html/plugins/Abeille/core/class/Abeille.class.php:627
    PHP   5. trim() /var/www/html/core/class/system.class.php:139
