### PR TITLE
Tools: PHP warning fix, getTrimmedValueForJsonFiles() should not be called statically

### DIFF
--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -227,7 +227,7 @@ class Tools
      * @param string $logger
      * @return array of json devices name
      */
-    public function getDeviceNameFromJson($logger = 'Abeille') {
+    public static function getDeviceNameFromJson($logger = 'Abeille') {
         $return = array();
         $devicesDir = dirname(__FILE__) . '/../../../core/config/devices/';
 

--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -214,13 +214,12 @@ class Tools
      * @param string $filename
      * @return mixed|string*
      */
-    public function getTrimmedValueForJsonFiles($filename = "") {
+    public static function getTrimmedValueForJsonFiles($filename = "") {
         //remove lumi. from name as all xiaomi devices have a lumi. name
         //remove all space in names for easier filename handling
         $trimmed = strlen($filename) > 1 ? str_replace(' ', '', str_replace('lumi.', '', $filename)) : "";
         return $trimmed;
     }
-
 
     /**
      * Scan config/devices directory to load devices name
@@ -259,7 +258,5 @@ class Tools
         return array_filter($return,function($value){return strlen($value)>1;});
     }
 }
-
-
 
 ?>


### PR DESCRIPTION
Voila une mise à jour pour ce genre de warning PHP
[28-May-2020 09:56:35 Europe/Brussels] PHP Deprecated:  Non-static method Tools::getTrimmedValueForJsonFiles() should not be called statically in /var/www/html/plugins/Abeille/desktop/php/Abeille.php on line 665

J'ai changé
    public function getTrimmedValueForJsonFiles($filename = "") {
en
    public static function getTrimmedValueForJsonFiles($filename = "") {
