### PR TITLE
AbeilleCmd: Robustness + debug msg update

### DIFF
--- a/resources/AbeilleDeamon/lib/Tools.php
+++ b/resources/AbeilleDeamon/lib/Tools.php
@@ -67,7 +67,8 @@ class Tools
         #fwrite(STDOUT, $loggerName . ' ' . date('Y-m-d H:i:s') . '['.strtoupper($loglevel). '='.$iLog.']/[' . strtoupper($GLOBALS['requestedlevel']) . '='.$iRequested. ']' . PHP_EOL);
         if (Tools::getNumberFromLevel($loglevel) <= Tools::getPluginLogLevel($pluginName)) {
             // fwrite(STDOUT,  '['.date('Y-m-d H:i:s').']['.$loggerName . '][' . $loglevel . ']' . $message . PHP_EOL);
-            fwrite(STDOUT,  '['.date('Y-m-d H:i:s').'][' . $loglevel . '] ' . $message . PHP_EOL);
+            /* Note: sprintf("%-5.5s", $loglevel) to have vertical alignment. Log level truncated to 5 chars => "warni" */
+            fwrite(STDOUT, '['.date('Y-m-d H:i:s').']['.sprintf("%-5.5s", $loglevel).'] '.$message.PHP_EOL);
         }
     }
 


### PR DESCRIPTION
Salut Kiwi.
J'attaque juste la découverte de cette partie qu'est 'AbeilleCmd'  pour progresser dans ma vue d'ensemble et mes soucis.

Voila une update essentiellement cosmetique mais quand meme avec qq checks revus.
J'avais listé ca
AbeilleCmd updates
- Cosmetic: spaces & indent
- Enhanced: processCmdQueueToZigate(): Checks if zigate is enabled moved from 'sendCmdToZigate()'
- Cosmetic: afficheStatQueue() => displayQueuesStatus() + msg revisited
- Cosmetic: Added some comments
- Enhanced: processCmd()
- Enhanced + fixes: sendCmd()
Tools::deamonlogFilter()
- Enhanced: Added 'sprintf("%-5.5s", $loglevel)' to have vertical alignement. Note: truncated to 5 chars.

Comme d'hab, toute remarque est bienvenue.