### PR TITLE
Debug: Added support for "debug.php" for developpers

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -16,6 +16,18 @@
      * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
      */
 
+    /* Developpers debug features */
+    $dbgFile = dirname(__FILE__)."/../../debug.php";
+    if (file_exists($dbgFile))
+        include_once $dbgFile;
+
+    /* Errors reporting: enabled if 'dbgAbeillePHP' is TRUE */
+    if (isset($dbgAbeillePHP) && ($dbgAbeillePHP == TRUE)) {
+        error_reporting(E_ALL);
+        ini_set('error_log', '/var/www/html/log/AbeillePHP');
+        ini_set('log_errors', 'On');
+    }
+
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/config.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
@@ -23,11 +35,6 @@
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
     include_once dirname(__FILE__).'/AbeilleMsg.php';
     include_once dirname(__FILE__).'/../../plugin_info/install.php'; // updateConfigDB()
-
-    /* Errors reporting: uncomment below lines for debug */
-    // error_reporting(E_ALL);
-    // ini_set('error_log', '/var/www/html/log/AbeillePHP');
-    // ini_set('log_errors', 'On');
 
     class Abeille extends eqLogic {
 

--- a/core/class/AbeilleCmd.php
+++ b/core/class/AbeilleCmd.php
@@ -1,21 +1,30 @@
 <?php
-    /***
-     * AbeilleCmd subscribe to Abeille topic and receive message sent by AbeilleParser.
+    /*
+     * AbeilleCmd
      *
-     *
+     * subscribe to Abeille topic and receive message sent by AbeilleParser.
      *
      */
 
+    /* Developpers debug features */
+    $dbgFile = dirname(__FILE__)."/../../debug.php";
+    if (file_exists($dbgFile))
+        include_once $dbgFile;
+
+    /* Errors reporting: enabled if 'dbgAbeillePHP' is TRUE */
+    if (isset($dbgAbeillePHP) && ($dbgAbeillePHP == TRUE)) {
+        error_reporting(E_ALL);
+        ini_set('error_log', '/var/www/html/log/AbeillePHP');
+        ini_set('log_errors', 'On');
+    }
+
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/config.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
-
     include_once dirname(__FILE__).'/AbeilleMsg.php';
-    
+
     class debug extends Tools {
         function deamonlog($loglevel = 'NONE', $message = "")
         {

--- a/core/class/AbeilleParser.php
+++ b/core/class/AbeilleParser.php
@@ -8,6 +8,18 @@
      * - then publish them to mosquitto
      */
 
+    /* Developpers debug features */
+    $dbgFile = dirname(__FILE__)."/../../debug.php";
+    if (file_exists($dbgFile))
+        include_once $dbgFile;
+
+    /* Errors reporting: enabled if 'dbgAbeillePHP' is TRUE */
+    if (isset($dbgAbeillePHP) && ($dbgAbeillePHP == TRUE)) {
+        error_reporting(E_ALL);
+        ini_set('error_log', '/var/www/html/log/AbeillePHP');
+        ini_set('log_errors', 'On');
+    }
+
     // Annonce -> populate NE-> get EP -> getName -> getLocation -> unset NE
 
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
@@ -15,11 +27,7 @@
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
-
-    /* Errors reporting: uncomment below lines for debug */
-    // error_reporting(E_ALL);
-    // ini_set('error_log', '/var/www/html/log/AbeillePHP');
-    // ini_set('log_errors', 'On');
+    include_once dirname(__FILE__).'/AbeilleMonitor.php'; // Tracing monitor for debug purposes
 
     $profileTable = array (
                            'c05e'=>'ZLL Application Profile',

--- a/core/class/AbeilleSerialRead.php
+++ b/core/class/AbeilleSerialRead.php
@@ -1,27 +1,37 @@
 <?php
 
-
-    /***
-     * AbeilleSerialRead
+    /*
+     * AbeilleSerialReadX
      *
-     * Get information from selected port (/dev/ttyUSB0 pour TTL ou socat pour WIFI), transcode data from binary to hex.
-     * and write it to FIFO file.
+     * - Read Zigate messages from selected port (/dev/ttyXX for USB & Pi, or thru socat for WIFI)
+     * - Transcode data from binary to hex.
+     * - and write it to FIFO file.
      *
-     * /usr/bin/php /var/www/html/plugins/Abeille/core/class/../../core/class/AbeilleSerialRead.php /tmp/zigate debug
+     * Usage:
+     * /usr/bin/php /var/www/html/plugins/Abeille/core/class/AbeilleSerialRead.php <AbeilleX> <ZigatePort> <DebugLevel>
      *
      */
 
+    /* Developpers debug features */
+    $dbgFile = dirname(__FILE__)."/../../debug.php";
+    if (file_exists($dbgFile))
+        include_once $dbgFile;
+
+    /* Errors reporting: enabled if 'dbgAbeillePHP' is TRUE */
+    if (isset($dbgAbeillePHP) && ($dbgAbeillePHP == TRUE)) {
+        error_reporting(E_ALL);
+        ini_set('error_log', '/var/www/html/log/AbeillePHP');
+        ini_set('log_errors', 'On');
+    }
 
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/config.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
-    
-    function deamonlog($loglevel='NONE',$message=""){
-        Tools::deamonlogFilter($loglevel,'Abeille', 'AbeilleSerialRead', $message);
+
+    function daemonlog($loglevel='NONE', $message=""){
+        Tools::deamonlogFilter($loglevel, 'Abeille', 'AbeilleSerialRead', $message);
     }
 
     function _exec($cmd, &$out = null)

--- a/core/class/AbeilleSocat.php
+++ b/core/class/AbeilleSocat.php
@@ -1,21 +1,28 @@
 <?php
 
-
-    /***
-     * AbeilleSerialRead
+    /*
+     * AbeilleSocat (daemon)
      *
-     * Get information from selected port (/dev/ttyUSB0 pour TTL ou socat pour WIFI), transcode data from binary to hex.
-     * and write it to FIFO file.
-     *
+     * - Using 'socat'
+     * - Convert TCP connection to 'tty' like port for later use by 'AbeileSerialRead'
      */
 
+    /* Developpers debug features */
+    $dbgFile = dirname(__FILE__)."/../../debug.php";
+    if (file_exists($dbgFile))
+        include_once $dbgFile;
+
+    /* Errors reporting: enabled if 'dbgAbeillePHP' is TRUE */
+    if (isset($dbgAbeillePHP) && ($dbgAbeillePHP == TRUE)) {
+        error_reporting(E_ALL);
+        ini_set('error_log', '/var/www/html/log/AbeillePHP');
+        ini_set('log_errors', 'On');
+    }
 
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/config.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
-    
     include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/Tools.php';
 
 


### PR DESCRIPTION
@KiwiHC16 
J'ai ajouté le support d'un fichier de config de debug dans les principaux demons.
Si tu cree un fichier local (debug.php) dans le plugin avec un contenu par ex comme suit

![image](https://user-images.githubusercontent.com/35221038/87541098-038fa000-c6a1-11ea-9f58-7061828001ec.png)

Tu peux activer la sortie des erreurs PHP sur "AbeillePHP".
Ca n'est qu'un exemple.
Tu peux ajouter toutes les variables de debug (et des fonctions peut etre aussi ?) pour tes besoins de dev sans toucher le code à pousser.

"debug.php" ne doit pas etre poussé. Il doit rester local et non versionné.
J'ai choisir de faire prefixer toutes les variables de debug par "dbg" pour les differencier.

Tu en penses quoi ?