### PR TITLE
PHP fix: Methods with the same name as their class will not be constr…

### DIFF
--- a/resources/AbeilleDeamon/includes/fifo.php
+++ b/resources/AbeilleDeamon/includes/fifo.php
@@ -3,14 +3,12 @@
 require_once(dirname(__FILE__).'/../lib/Tools.php');
 require_once dirname(__FILE__).'/../../../../../core/php/core.inc.php';
 
-
 ob_implicit_flush();
 
 class fifo {
 
-
-	var $fp;
-	var $to;
+    var $fp;
+    var $to;
 
     /**
      * Create a first In first Out file according to given parameters
@@ -18,34 +16,34 @@ class fifo {
      * @param $file
      * @param $mode /!\ the permissions of the created file are (mode & ~umask).
      */
-	function fifo( $file, $mode, $readWrite )
-	{
-		if( !file_exists( $file ) ) 
-		{
-			print "creating fifo $file for $mode\n";
-			if( !posix_mkfifo( $file, $mode ) )
-			{
-				die( "could not create named pipe $file\n" );
-			}
-			chown($file, "www-data");
-		}
-		//print "opening fifo $file for $readWrite\n";
-		$this->fp = fopen( $file, $readWrite );
+    public function __construct($file, $mode, $readWrite)
+    {
+        if( !file_exists( $file ) ) 
+        {
+            print "creating fifo $file for $mode\n";
+            if( !posix_mkfifo( $file, $mode ) )
+            {
+                die( "could not create named pipe $file\n" );
+            }
+            chown($file, "www-data");
+        }
+        //print "opening fifo $file for $readWrite\n";
+        $this->fp = fopen( $file, $readWrite );
         // prevent fread / fwrite blocking
         stream_set_blocking($this->fp, false);
-	}
+    }
 
     /* Cette version de la fonction read utilise 30% du CPU RPI3 donc on la remplace par la suivante ci dessous.
-	function read() {
-	// reads a line from a fifo file
-		$line = '';
-		do 
-		{
-			$c = fgetc( $this->fp );
-			if( ($c != '') and ($c != "\n") and !feof( $this->fp ) ) $line .= $c;
-		} while( ($c != '') and ($c != "\n") and !feof( $this->fp ) );
-		return $line;
-	}
+    function read() {
+    // reads a line from a fifo file
+        $line = '';
+        do 
+        {
+            $c = fgetc( $this->fp );
+            if( ($c != '') and ($c != "\n") and !feof( $this->fp ) ) $line .= $c;
+        } while( ($c != '') and ($c != "\n") and !feof( $this->fp ) );
+        return $line;
+    }
     */
     
     function read() {
@@ -64,16 +62,15 @@ class fifo {
         }
     }
 
-	function write( $data ) {
-		fputs( $this->fp, $data );
-		fflush( $this->fp );
-	}
-	
-	function close()
-	{
-		fclose($this->fp);
-	}
-
+    function write( $data ) {
+        fputs( $this->fp, $data );
+        fflush( $this->fp );
+    }
+    
+    function close()
+    {
+        fclose($this->fp);
+    }
 }
 
 ?>


### PR DESCRIPTION
…uctors

PHP fix for the following error
[15-Jul-2020 14:45:06 Europe/Brussels] PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; fifo has a deprecated constructor in /var/www/html/plugins/Abeille/resources/AbeilleDeamon/includes/fifo.php on line 9

