### PR TITLE
PiZigate: Checks if Jennic prog is executable

### DIFF
--- a/resources/updateFirmware.sh
+++ b/resources/updateFirmware.sh
@@ -35,6 +35,11 @@ if [ ! -e ${PROG} ]; then
     echo "=         ${PROG}"
     error=1
 fi
+if [ ! -x ${PROG} ]; then
+    echo "= ERREUR: Le programmateur Jennic n'est pas exécutable !"
+    echo "=         ${PROG}"
+    error=1
+fi
 if [ $error != 0 ]; then
     exit 1
 fi


### PR DESCRIPTION
Check supplementaire lors de la programmation PiZigate.
Je verifie que le programmateur est executable.
Un des pbs rencontrés avec Bornich: https://community.jeedom.com/t/firmware-pizigate/32258/46