### PR TITLE
PHP warning fix: Creating default object from empty value

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -779,6 +779,7 @@
                 $msg_type = NULL;
                 $msg = NULL;
                 $max_msg_size = 512;
+                $message = new MsgAbeille;
 
                 // https: github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
                 // #define    ENOMSG        42    /* No message of desired type */
@@ -792,8 +793,8 @@
                         $msg_type = NULL;
                         $msg = NULL;
                     }
-                    if ( ($errorcodeMsg!=42) and ($errorcodeMsg!=0) ) {
-                        log::add('Abeille', 'debug', 'deamon fct: msg_receive queueKeyAbeilleToAbeille issue: '.$errorcodeMsg);
+                    if (($errorcodeMsg!=42) and ($errorcodeMsg!=0)) {
+                        log::add('Abeille', 'error', 'Erreur inattendue, lecture queue \'AbeilleToAbeille\': '.$errorcodeMsg);
                     }
 
                     if (msg_receive( $queueKeyParserToAbeille, 0, $msg_type, $max_msg_size, $msg, true, MSG_IPC_NOWAIT, $errorcodeMsg)) {


### PR DESCRIPTION
Voila le fix pour le message suivant: 
[11-Aug-2020 22:17:13 Europe/Brussels] PHP Warning:  Creating default object from empty value in /var/www/html/plugins/Abeille/core/class/Abeille.class.php on line 820