### PR TITLE
test gpio, ajout d'info dans la configuration pour docker

### DIFF
--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -299,7 +299,7 @@
             <div>
                 <p><i>{{La PiZiGate est controllée par un port TTY + 2x GPIO dépendant de votre plateforme.}}</i></p>
                 <p><i>{{Le logiciel 'WiringPi' (ou équivalent) est nécessaire pour piloter ces GPIOs.}}</i></p>
-                <p><i>{{Attention l'accès aux GPIOs ne se fait pas depuis un container sous Docker (si vous savez faire alors donnez moi la combine). Dans ce cas faites les manipulations à la main depuis le host.}}</i></p>
+                <p><i>{{L'accès aux GPIOs peut se faire depuis un container sous Docker, il faut ajouter --device /dev/mem et --cap_add SYS_RAWIO). Dans ce cas, faites les manipulations au lancement du conteneur.}}</i></p>
             </div>
 
             <div class="form-group">

--- a/resources/checkSocat.sh
+++ b/resources/checkSocat.sh
@@ -5,7 +5,7 @@ echo "[${NOW}] Démarrage de '$(basename $0)'"
 
 # 'socat'
 echo "Vérification de l'installation du package 'socat'"
-hash socat 2>/dev/null
+command -v socat
 if [ $? -ne 0 ]; then
     echo "= ERREUR: Commande 'socat' manquante !"
     echo "=         Le package 'socat' semble mal installé."

--- a/resources/checkTTY.sh
+++ b/resources/checkTTY.sh
@@ -57,7 +57,7 @@ fi
 if [ "${TYPE}" == "PI" ]; then
     # 'gpio' commands are provided from "WiringPi" package (or equivalent)
     echo "Vérification de l'installation du package 'WiringPi'"
-    hash gpio 2>/dev/null
+    command -v gpio
     if [ $? -ne 0 ]; then
         echo "= ERREUR: Commande 'gpio' manquante !"
         echo "=         Le package 'WiringPi' est probablement mal installé."

--- a/resources/checkWiringPi.sh
+++ b/resources/checkWiringPi.sh
@@ -5,7 +5,7 @@ echo "[${NOW}] Démarrage de '$(basename $0)'"
 
 # 'gpio' commands are provided from "WiringPi" package (or equivalent)
 echo "Vérification de l'installation du package 'WiringPi'"
-hash gpio 2>/dev/null
+command -v gpio
 if [ $? -ne 0 ]; then
     echo "= ERREUR: Commande 'gpio' manquante !"
     echo "=         Le package WiringPi est probablement mal installé."

--- a/resources/installSocat.sh
+++ b/resources/installSocat.sh
@@ -18,7 +18,7 @@ fi
 echo "= Ok, package installé."
 
 echo "Vérification finale de 'socat'"
-hash socat 2>/dev/null
+command -v socat
 if [ $? -ne 0 ]; then
     echo "= ERREUR: Commande 'socat' manquante !"
     echo "=         Le package 'socat' semble être mal installé."

--- a/resources/installWiringPi.sh
+++ b/resources/installWiringPi.sh
@@ -39,7 +39,7 @@ fi
 echo "= Ok"
 
 echo "Vérification finale"
-hash gpio 2>/dev/null
+command -v gpio
 if [ $? -ne 0 ]; then
     echo "= ERREUR: Commande 'gpio' manquante !"
     echo "=         Le package WiringPi semble être mal installé."

--- a/resources/resetPiZigate.sh
+++ b/resources/resetPiZigate.sh
@@ -4,7 +4,7 @@ NOW=`date +"%Y-%m-%d %H:%M:%S"`
 echo "[${NOW}] Démarrage de '$(basename $0)'"
 
 echo "Vérification de l'installation WiringPi"
-hash gpio 2>/dev/null
+command -v gpio
 if [ $? -ne 0 ]; then
     echo "= ERREUR: Commande 'gpio' manquante !"
     echo "=         Le package WiringPi est probablement mal installé."

--- a/resources/updateFirmware.sh
+++ b/resources/updateFirmware.sh
@@ -38,7 +38,7 @@ else
         echo "=         Port: ${ZGPORT}"
         error=1
     fi
-    hash gpio 2>/dev/null
+    command -v gpio
     if [ $? -ne 0 ]; then
         echo "= ERREUR: Commande 'gpio' manquante !"
         echo "=         Le package WiringPi est probablement mal installé."


### PR DESCRIPTION
pour avoir accès au gpio depuis un conteneur, il faut ajouter cap-add SYSRAWIO et --device /dev/mem

Ajout d'un commentaire dans la configuration pour donner cette information

Test de la présence et de l'executabilité de la commande gpio.