### PR TITLE
Move abeille cmd

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,36 +1,41 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Sonar
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    push:
+        branches: [ master, dev ]
+    pull_request:
+        types: [ opened, synchronize, reopened ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  analyze:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    name: sonar analysis
+    # This workflow contains a single job called "build"
+    analyze:
+        # The type of runner that the job will run on
+        runs-on: ubuntu-latest
+        name: sonar analysis
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+        # Steps represent a sequence of tasks that will be executed as part of the job
+        steps:
+            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+            -   uses: actions/checkout@v2
+                # Disabling shallow clone is recommended for improving relevancy of reporting
+                with:
+                    fetch-depth: 0
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
-          # Additional arguments to the sonarcloud scanner
-          args: # optional
-          # Set the sonar.projectBaseDir analysis property  
+            -   name: SonarCloud Scan
+                uses: SonarSource/sonarcloud-github-action@v1.4
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_SONAR }}
+                    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                with:
+                    # Additional arguments to the sonarcloud scanner
+                    # Set the sonar.projectBaseDir analysis property
+                    #projectBaseDir: .
+                    # optional
+                    args: >
+                        -Dfile.encoding=fr_FR.UTF-8
+                        -Dsun.jnu.encoding=fr_FR.UTF-8

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -32,6 +32,7 @@ if (file_exists($dbgFile)) {
     include_once __DIR__.'/../../resources/AbeilleDeamon/includes/fifo.php';
     include_once __DIR__.'/../../resources/AbeilleDeamon/lib/AbeilleTools.php';
     include_once __DIR__.'/AbeilleMsg.php';
+    include_once __DIR__.'/AbeilleCmd.class.php';
     include_once __DIR__.'/../../plugin_info/install.php'; // updateConfigDB()
 
 class Abeille extends eqLogic
@@ -75,7 +76,7 @@ class Abeille extends eqLogic
                     log::add('Abeille', 'debug', 'Erreur je n ai pas l IEEE je ne sais comment gerer.');
                     return;
                 }
-                self::publishMosquitto( $this->queueKeyAbeilleToCmd, priorityNeWokeUp, "Cmd".$destGhost."/Ruche/Remove", "IEEE=".$IEEE );
+                self::publishMosquitto( queueKeyAbeilleToCmd, priorityNeWokeUp, "Cmd".$destGhost."/Ruche/Remove", "IEEE=".$IEEE );
             }
 
         // Parcours toutes les commandes
@@ -1744,159 +1745,6 @@ class Abeille extends eqLogic
             $cmdlogic->save();
             $elogic->checkAndUpdateCmd($cmdId, $cmdValueDefaut["value"]);
         }
-    }
-}
-
-class AbeilleCmd extends cmd
-{
-    public function execute($_options = null)
-    {
-
-        log::add('Abeille', 'Debug', 'execute ->' . $this->getType() . '<- function with options ->' . json_encode($_options) . '<-');
-
-        // cmdId : 12676 est le level d une ampoule
-        // la cmdId 12680 a pour value 12676
-        // Donc apres avoir fait un setLevel (12680) qui change le Level (12676), la cmdId setLvele est appelée avec le parametre: "cmdIdUpdated":"12676"
-        // On le voit dans le log avec:
-        // [2020-01-30 03:39:22][DEBUG] : execute ->action<- function with options ->{"cmdIdUpdated":"12676"}<-
-        if (isset($_options['cmdIdUpdated'])) return;
-
-        switch ($this->getType()) {
-            case 'action' :
-                //
-                /* ------------------------------ */
-                // Topic est l arborescence MQTT: La fonction Zigate
-
-                $Abeilles = new Abeille();
-
-                $NE_Id = $this->getEqLogic_id();
-                $NE = $Abeilles->byId($NE_Id);
-
-                if (strpos("_" . $this->getConfiguration('topic'), "CmdAbeille") == 1) {
-                    $topic = $this->getConfiguration('topic');
-                } else {
-                    if (strpos("_" . $this->getConfiguration('topic'), "CmdCreate") == 1) {
-                        $topic = $this->getConfiguration('topic');
-                    } else {
-                        $topic = "Cmd" . $NE->getConfiguration('topic') . "/" . $this->getConfiguration('topic');
-                    }
-                }
-
-                if (strpos("_" . $this->getConfiguration('topic'), "CmdAbeille") == 1) {
-                    // if ( $NE->getConfiguration('Zigate') > 1 ) {
-                    //     $topic = str_replace( "CmdAbeille", "CmdAbeille".$NE->getConfiguration("Zigate"), $topic );
-                    // }
-                    $topicNEArray = explode("/", $NE->getConfiguration("topic"));
-                    $destNE = str_replace("Abeille", "", $topicNEArray[0]);
-                    $topic = str_replace("CmdAbeille", "CmdAbeille" . $destNE, $topic);
-                }
-
-                log::add('Abeille', 'Debug', 'topic: ' . $topic);
-
-                $topicArray = explode("/", $topic);
-                $dest = substr($topicArray[0], 3);
-
-                /* ------------------------------ */
-                // Je fais les remplacement dans la commande (ex: addGroup pour telecommande Ikea 5 btn)
-                if (strpos($topic, "#addrGroup#") > 0) {
-                    $topic = str_replace("#addrGroup#", $NE->getConfiguration("Groupe"), $topic);
-                }
-
-                // -------------------------------------------------------------------------
-                // Process Request
-                $request = $this->getConfiguration('request', '1');
-                // request: c'est le payload dans la page de configuration pour une commande
-                // C est les parametres de la commande pour la zigate
-                log::add('Abeille', 'Debug', 'request: ' . $request);
-
-                /* ------------------------------ */
-                // Je fais les remplacement dans la commande (ex: addGroup pour telecommande Ikea 5 btn)
-                if (strpos($request, "#addrGroup#") > 0) {
-                    $request = str_replace("#addrGroup#", $NE->getConfiguration("Groupe"), $request);
-                }
-
-                /* ------------------------------ */
-                // Je fais les remplacement dans les parametres
-                if (strpos($request, '#onTime#') > 0) {
-                    $onTimeHex = sprintf("%04s", dechex($NE->getConfiguration("onTime") * 10));
-                    $request = str_replace("#onTime#", $onTimeHex, $request);
-                }
-
-                if (strpos($request, '#addrIEEE#') > 0) {
-                    $ruche = new Abeille();
-                    $command = new AbeilleCmd();
-
-                    // Recupere IEEE de la Ruche/ZiGate
-                    $rucheId = $ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getId();
-                    log::add('Abeille', 'debug', 'Id pour abeille Ruche: ' . $rucheId);
-
-                    if (strlen($ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getConfiguration('IEEE', 'none')) == 16) {
-                        $rucheIEEE = $ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getConfiguration('IEEE', 'none');
-                    } else {
-                        $rucheIEEE = $commandIEEE->byEqLogicIdAndLogicalId($rucheId, 'IEEE-Addr')->execCmd();
-                    }
-                    log::add('Abeille', 'debug', 'IEEE pour  Ruche: ' . $rucheIEEE);
-
-                    $currentCommandId = $this->getId();
-                    $currentObjectId = $this->getEqLogic_id();
-                    log::add('Abeille', 'debug', 'Id pour current abeille: ' . $currentObjectId);
-
-                    // ne semble pas rendre la main si l'objet n'a pas de champ "IEEE-Addr"
-                    $commandIEEE = $command->byEqLogicIdAndLogicalId($currentObjectId, 'IEEE-Addr')->execCmd();
-
-                    // print_r( $command->execCmd() );
-                    log::add('Abeille', 'debug', 'IEEE pour current abeille: ' . $commandIEEE);
-
-                    // $elogic->byLogicalId( 'Abeille/b528', 'Abeille' );
-                    // print_r( $objet->byLogicalId( 'Abeille/b528', 'Abeille' )->getId() );
-                    // echo "\n";
-                    // print_r( $command->byEqLogicIdAndLogicalId( $objetId, "IEEE-Addr" )->getLastValue() );
-
-                    $request = str_replace('#addrIEEE#', $commandIEEE, $request);
-                    $request = str_replace('#ZiGateIEEE#', $rucheIEEE, $request);
-                }
-
-                switch ($this->getSubType()) {
-                    case 'slider':
-                        $request = str_replace('#slider#', $_options['slider'], $request);
-                        break;
-                    case 'color':
-                        $request = str_replace('#color#', $_options['color'], $request);
-                        break;
-                    case 'message':
-                        $request = str_replace('#title#', $_options['title'], $request);
-                        $request = str_replace('#message#', $_options['message'], $request);
-                        break;
-                }
-
-                $request = str_replace('\\', '', jeedom::evaluateExpression($request));
-                $request = cmd::cmdToValue($request);
-
-                $msgAbeille = new MsgAbeille;
-
-                $msgAbeille->message['topic'] = $topic;
-                $msgAbeille->message['payload'] = $request;
-
-                log::add('Abeille', 'Debug', 'topic: ' . $topic . ' request: ' . $request);
-
-                if (strpos($topic, "CmdCreate") === 0) {
-                    $queueKeyAbeilleToAbeille = msg_get_queue(queueKeyAbeilleToAbeille);
-                    if (msg_send($queueKeyAbeilleToAbeille, 1, $msgAbeille, true, false)) {
-                        log::add('Abeille', 'debug', '(CmdCreate) Msg sent: ' . json_encode($msgAbeille));
-                    } else {
-                        log::add('Abeille', 'debug', '(CmdCreate) Could not send Msg');
-                    }
-                } else {
-                    $queueKeyAbeilleToCmd = msg_get_queue(queueKeyAbeilleToCmd);
-                    if (msg_send($queueKeyAbeilleToCmd, priorityUserCmd, $msgAbeille, true, false)) {
-                        log::add('Abeille', 'debug', '(All) Msg sent: ' . json_encode($msgAbeille));
-                    } else {
-                        log::add('Abeille', 'debug', '(All) Could not send Msg');
-                    }
-                }
-        }
-
-        return true;
     }
 }
 

--- a/core/class/AbeilleCmd.class.php
+++ b/core/class/AbeilleCmd.class.php
@@ -1,0 +1,156 @@
+<?php
+
+class AbeilleCmd extends cmd
+{
+    public function execute($_options = null)
+    {
+
+        log::add('Abeille', 'Debug', 'execute ->' . $this->getType() . '<- function with options ->' . json_encode($_options) . '<-');
+
+// cmdId : 12676 est le level d une ampoule
+// la cmdId 12680 a pour value 12676
+// Donc apres avoir fait un setLevel (12680) qui change le Level (12676), la cmdId setLvele est appelée avec le parametre: "cmdIdUpdated":"12676"
+// On le voit dans le log avec:
+// [2020-01-30 03:39:22][DEBUG] : execute ->action<- function with options ->{"cmdIdUpdated":"12676"}<-
+        if (isset($_options['cmdIdUpdated'])) return;
+
+        switch ($this->getType()) {
+            case 'action' :
+//
+                /* ------------------------------ */
+// Topic est l arborescence MQTT: La fonction Zigate
+
+                $Abeilles = new Abeille();
+
+                $NE_Id = $this->getEqLogic_id();
+                $NE = $Abeilles->byId($NE_Id);
+
+                if (strpos("_" . $this->getConfiguration('topic'), "CmdAbeille") == 1) {
+                    $topic = $this->getConfiguration('topic');
+                } else {
+                    if (strpos("_" . $this->getConfiguration('topic'), "CmdCreate") == 1) {
+                        $topic = $this->getConfiguration('topic');
+                    } else {
+                        $topic = "Cmd" . $NE->getConfiguration('topic') . "/" . $this->getConfiguration('topic');
+                    }
+                }
+
+                if (strpos("_" . $this->getConfiguration('topic'), "CmdAbeille") == 1) {
+// if ( $NE->getConfiguration('Zigate') > 1 ) {
+//     $topic = str_replace( "CmdAbeille", "CmdAbeille".$NE->getConfiguration("Zigate"), $topic );
+// }
+                    $topicNEArray = explode("/", $NE->getConfiguration("topic"));
+                    $destNE = str_replace("Abeille", "", $topicNEArray[0]);
+                    $topic = str_replace("CmdAbeille", "CmdAbeille" . $destNE, $topic);
+                }
+
+                log::add('Abeille', 'Debug', 'topic: ' . $topic);
+
+                $topicArray = explode("/", $topic);
+                $dest = substr($topicArray[0], 3);
+
+                /* ------------------------------ */
+// Je fais les remplacement dans la commande (ex: addGroup pour telecommande Ikea 5 btn)
+                if (strpos($topic, "#addrGroup#") > 0) {
+                    $topic = str_replace("#addrGroup#", $NE->getConfiguration("Groupe"), $topic);
+                }
+
+// -------------------------------------------------------------------------
+// Process Request
+                $request = $this->getConfiguration('request', '1');
+// request: c'est le payload dans la page de configuration pour une commande
+// C est les parametres de la commande pour la zigate
+                log::add('Abeille', 'Debug', 'request: ' . $request);
+
+                /* ------------------------------ */
+// Je fais les remplacement dans la commande (ex: addGroup pour telecommande Ikea 5 btn)
+                if (strpos($request, "#addrGroup#") > 0) {
+                    $request = str_replace("#addrGroup#", $NE->getConfiguration("Groupe"), $request);
+                }
+
+                /* ------------------------------ */
+// Je fais les remplacement dans les parametres
+                if (strpos($request, '#onTime#') > 0) {
+                    $onTimeHex = sprintf("%04s", dechex($NE->getConfiguration("onTime") * 10));
+                    $request = str_replace("#onTime#", $onTimeHex, $request);
+                }
+
+                if (strpos($request, '#addrIEEE#') > 0) {
+                    $ruche = new Abeille();
+                    $command = new AbeilleCmd();
+
+// Recupere IEEE de la Ruche/ZiGate
+                    $rucheId = $ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getId();
+                    log::add('Abeille', 'debug', 'Id pour abeille Ruche: ' . $rucheId);
+
+                    if (strlen($ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getConfiguration('IEEE', 'none')) == 16) {
+                        $rucheIEEE = $ruche->byLogicalId($dest . '/Ruche', 'Abeille')->getConfiguration('IEEE', 'none');
+                    } else {
+                        $rucheIEEE = $commandIEEE->byEqLogicIdAndLogicalId($rucheId, 'IEEE-Addr')->execCmd();
+                    }
+                    log::add('Abeille', 'debug', 'IEEE pour  Ruche: ' . $rucheIEEE);
+
+                    $currentCommandId = $this->getId();
+                    $currentObjectId = $this->getEqLogic_id();
+                    log::add('Abeille', 'debug', 'Id pour current abeille: ' . $currentObjectId);
+
+// ne semble pas rendre la main si l'objet n'a pas de champ "IEEE-Addr"
+                    $commandIEEE = $command->byEqLogicIdAndLogicalId($currentObjectId, 'IEEE-Addr')->execCmd();
+
+// print_r( $command->execCmd() );
+                    log::add('Abeille', 'debug', 'IEEE pour current abeille: ' . $commandIEEE);
+
+// $elogic->byLogicalId( 'Abeille/b528', 'Abeille' );
+// print_r( $objet->byLogicalId( 'Abeille/b528', 'Abeille' )->getId() );
+// echo "\n";
+// print_r( $command->byEqLogicIdAndLogicalId( $objetId, "IEEE-Addr" )->getLastValue() );
+
+                    $request = str_replace('#addrIEEE#', $commandIEEE, $request);
+                    $request = str_replace('#ZiGateIEEE#', $rucheIEEE, $request);
+                }
+
+                switch ($this->getSubType()) {
+                    case 'slider':
+                        $request = str_replace('#slider#', $_options['slider'], $request);
+                        break;
+                    case 'color':
+                        $request = str_replace('#color#', $_options['color'], $request);
+                        break;
+                    case 'message':
+                        $request = str_replace('#title#', $_options['title'], $request);
+                        $request = str_replace('#message#', $_options['message'], $request);
+                        break;
+                }
+
+                $request = str_replace('\\', '', jeedom::evaluateExpression($request));
+                $request = cmd::cmdToValue($request);
+
+                $msgAbeille = new MsgAbeille;
+
+                $msgAbeille->message['topic'] = $topic;
+                $msgAbeille->message['payload'] = $request;
+
+                log::add('Abeille', 'Debug', 'topic: ' . $topic . ' request: ' . $request);
+
+                if (strpos($topic, "CmdCreate") === 0) {
+                    $queueKeyAbeilleToAbeille = msg_get_queue(queueKeyAbeilleToAbeille);
+                    if (msg_send($queueKeyAbeilleToAbeille, 1, $msgAbeille, true, false)) {
+                        log::add('Abeille', 'debug', '(CmdCreate) Msg sent: ' . json_encode($msgAbeille));
+                    } else {
+                        log::add('Abeille', 'debug', '(CmdCreate) Could not send Msg');
+                    }
+                } else {
+                    $queueKeyAbeilleToCmd = msg_get_queue(queueKeyAbeilleToCmd);
+                    if (msg_send($queueKeyAbeilleToCmd, priorityUserCmd, $msgAbeille, true, false)) {
+                        log::add('Abeille', 'debug', '(All) Msg sent: ' . json_encode($msgAbeille));
+                    } else {
+                        log::add('Abeille', 'debug', '(All) Could not send Msg');
+                    }
+                }
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/resources/AbeilleDeamon/AbeilleCmd.php
+++ b/resources/AbeilleDeamon/AbeilleCmd.php
@@ -1,6 +1,6 @@
 <?php
     /*
-     * AbeilleCmd
+     * démon AbeilleCmd
      *
      * subscribe to Abeille topic and receive message sent by AbeilleParser.
      *
@@ -17,14 +17,14 @@
     }
 
     include_once __DIR__.'/../../../../core/php/core.inc.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/config.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/function.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/fifo.php';
-    
-    include_once __DIR__.'/AbeilleMsg.php';
-    include_once __DIR__.'/../php/AbeilleLog.php';
+    include_once __DIR__.'/includes/config.php';
+    include_once __DIR__.'/includes/function.php';
+    include_once __DIR__.'/includes/fifo.php';
 
-    include_once __DIR__.'/AbeilleCmdQueue.class.php';
+    include_once __DIR__.'/../../core/class/AbeilleMsg.php';
+    include_once __DIR__.'/../../core/php/AbeilleLog.php';
+
+    include_once __DIR__.'/../../core/class/AbeilleCmdQueue.class.php';
 
     // ***********************************************************************************************
     // MAIN

--- a/resources/AbeilleDeamon/AbeilleInterrogate.php
+++ b/resources/AbeilleDeamon/AbeilleInterrogate.php
@@ -16,8 +16,7 @@
      * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
      */
 
-    include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
-
+    include_once __DIR__.'/../../../core/php/core.inc.php';
     include_once dirname(__FILE__).'/includes/config.php';
     include_once dirname(__FILE__).'/includes/function.php';
     include_once dirname(__FILE__).'/includes/fifo.php';

--- a/resources/AbeilleDeamon/AbeilleInterrogate.php
+++ b/resources/AbeilleDeamon/AbeilleInterrogate.php
@@ -18,11 +18,11 @@
 
     include_once dirname(__FILE__).'/../../../../core/php/core.inc.php';
 
-    include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/config.php';
-    include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/function.php';
-    include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/includes/fifo.php';
+    include_once dirname(__FILE__).'/includes/config.php';
+    include_once dirname(__FILE__).'/includes/function.php';
+    include_once dirname(__FILE__).'/includes/fifo.php';
 
-    include_once dirname(__FILE__).'/../../resources/AbeilleDeamon/lib/AbeilleTools.php';
+    include_once dirname(__FILE__).'/lib/AbeilleTools.php';
 
 
     /*

--- a/resources/AbeilleDeamon/AbeilleParser.php
+++ b/resources/AbeilleDeamon/AbeilleParser.php
@@ -21,12 +21,12 @@
     // Annonce -> populate NE-> get EP -> getName -> getLocation -> unset NE
 
     include_once __DIR__.'/../../../../core/php/core.inc.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/config.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/function.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/fifo.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/lib/AbeilleTools.php';
-    include_once __DIR__.'/../php/AbeilleLog.php'; // Abeille log features
-    include_once __DIR__.'/../php/AbeilleZigateConst.php'; // Zigate constants
+    include_once __DIR__.'/includes/config.php';
+    include_once __DIR__.'/includes/function.php';
+    include_once __DIR__.'/includes/fifo.php';
+    include_once __DIR__.'/lib/AbeilleTools.php';
+    include_once __DIR__.'/../../core/php/AbeilleLog.php'; // Abeille log features
+    include_once __DIR__.'/../../core/php/AbeilleZigateConst.php'; // Zigate constants
 
     // Needed for decode8701 and decode8702
     // Voir https://github.com/fairecasoimeme/ZiGate/issues/161

--- a/resources/AbeilleDeamon/AbeilleSerialRead.php
+++ b/resources/AbeilleDeamon/AbeilleSerialRead.php
@@ -22,12 +22,12 @@
         ini_set('log_errors', 'On');
     }
 
-    include_once __DIR__.'/../../../../core/php/core.inc.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/config.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/function.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/fifo.php';
+    include_once __DIR__.'/../../../core/php/core.inc.php';
+    include_once __DIR__.'/includes/config.php';
+    include_once __DIR__.'/includes/function.php';
+    include_once __DIR__.'/includes/fifo.php';
     // include_once __DIR__.'/../../resources/AbeilleDeamon/lib/AbeilleTools.php';
-    include_once __DIR__.'/AbeilleLog.php';
+    include_once __DIR__.'/../../core/php/AbeilleLog.php';
 
     logSetConf(); // Log to STDOUT until log name fully known (need Zigate number)
     logMessage('info', 'Démarrage d\'AbeilleSerialRead sur port '.$argv[2]);

--- a/resources/AbeilleDeamon/AbeilleSerialRead.php
+++ b/resources/AbeilleDeamon/AbeilleSerialRead.php
@@ -22,7 +22,7 @@
         ini_set('log_errors', 'On');
     }
 
-    include_once __DIR__.'/../../../core/php/core.inc.php';
+    include_once __DIR__.'/../../../../core/php/core.inc.php';
     include_once __DIR__.'/includes/config.php';
     include_once __DIR__.'/includes/function.php';
     include_once __DIR__.'/includes/fifo.php';

--- a/resources/AbeilleDeamon/AbeilleSocat.php
+++ b/resources/AbeilleDeamon/AbeilleSocat.php
@@ -18,11 +18,11 @@
     }
 
     include_once __DIR__.'/../../../../core/php/core.inc.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/config.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/function.php';
-    include_once __DIR__.'/../../resources/AbeilleDeamon/includes/fifo.php';
+    include_once __DIR__.'/includes/config.php';
+    include_once __DIR__.'/includes/function.php';
+    include_once __DIR__.'/includes/fifo.php';
     // include_once __DIR__.'/../../resources/AbeilleDeamon/lib/AbeilleTools.php';
-    include_once __DIR__.'/AbeilleLog.php';
+    include_once __DIR__.'/../../core/php/AbeilleLog.php';
 
     logSetConf(); // Log to STDOUT until log name fully known (need Zigate number)
     logMessage('info', 'Démarrage d\'AbeilleSocat');

--- a/resources/AbeilleDeamon/lib/AbeilleTools.php
+++ b/resources/AbeilleDeamon/lib/AbeilleTools.php
@@ -9,7 +9,7 @@ class AbeilleTools
     const templateDir = __DIR__ . '/../../../core/config/devices/Template/';
     const devicesDir = __DIR__ . '/../../../core/config/devices/';
     const configDir = __DIR__ . '/../../../core/config/';
-    const daemonDir = __DIR__ .'/../';
+    const daemonDir = __DIR__ . '/../';
     const logDir = __DIR__ . "/../../../../../log/";
 
     /**
@@ -102,7 +102,7 @@ class AbeilleTools
 
         $cmdJson = json_decode($content, true);
         if (json_last_error() != JSON_ERROR_NONE) {
-            log::add('Abeille','error', 'getJSonConfigFilebyDevices: filename content is not a json: ' . $content);
+            log::add('Abeille', 'error', 'getJSonConfigFilebyDevices: filename content is not a json: ' . $content);
             return array();
         }
 
@@ -129,8 +129,8 @@ class AbeilleTools
         // Recupere le template master
         $deviceTemplate = json_decode($content, true);
         if (json_last_error() != JSON_ERROR_NONE) {
-            log::add('Abeille','error', 'L\'équipement \'' . $device . '\' a un mauvais fichier JSON.');
-            log::add('Abeille','debug', 'getJSonConfigFilebyDevices(): content=' . $content);
+            log::add('Abeille', 'error', 'L\'équipement \'' . $device . '\' a un mauvais fichier JSON.');
+            log::add('Abeille', 'debug', 'getJSonConfigFilebyDevices(): content=' . $content);
             return;
         }
 
@@ -174,13 +174,13 @@ class AbeilleTools
 
         //file exists ?
         if (!is_file($confFile)) {
-            log::add('Abeille','error', $confFile . ' not found.');
+            log::add('Abeille', 'error', $confFile . ' not found.');
             return;
         }
         // is valid json
         $content = file_get_contents($confFile);
         if (!is_json($content)) {
-            log::add('Abeille','error', $confFile . ' is not a valid json.');
+            log::add('Abeille', 'error', $confFile . ' is not a valid json.');
             return;
         }
 
@@ -212,7 +212,7 @@ class AbeilleTools
 
         $deviceJson = json_decode($content, true);
         if (json_last_error() != JSON_ERROR_NONE) {
-            log::add('Abeille','error', 'getJSonConfigFilebyDevices: filename content is not a json: ' . $content);
+            log::add('Abeille', 'error', 'getJSonConfigFilebyDevices: filename content is not a json: ' . $content);
             return;
         }
 
@@ -245,7 +245,7 @@ class AbeilleTools
         $return = array();
         $devicesDir = self::devicesDir;
         if (file_exists($devicesDir) == FALSE) {
-            log::add('Abeille','error', "Problème d'installation. Le chemin '...core/config/devices' n'existe pas.");
+            log::add('Abeille', 'error', "Problème d'installation. Le chemin '...core/config/devices' n'existe pas.");
             return $return;
         }
 
@@ -372,7 +372,7 @@ class AbeilleTools
             ', running: ' . implode(',', $running));
         //log::add('Abeille', 'Info', 'Tools:isMissingDaemons:' . ($result==1?"Yes":"No"));
         if ($result == 1) {
-            log::add('Abeille','Warning', 'Abeille: il manque au moins un processus pour gérer la zigate');
+            log::add('Abeille', 'Warning', 'Abeille: il manque au moins un processus pour gérer la zigate');
             message::add("Abeille", "Danger,  il manque au moins un processus pour gérer la zigate");
         }
 
@@ -391,7 +391,7 @@ class AbeilleTools
         //get socat first
         arsort($found);
         array_reverse($found);
-        log::add( 'Abeille','debug', 'Tools:restartMissingDaemons: lastLaunch: ' . $lastLaunch . ',running:' . print_r($found, true));
+        log::add('Abeille', 'debug', 'Tools:restartMissingDaemons: lastLaunch: ' . $lastLaunch . ',running:' . print_r($found, true));
 
         $missing = "";
         foreach ($found as $daemon => $value) {
@@ -447,7 +447,7 @@ class AbeilleTools
                 $daemonPhp = "AbeilleSocat.php";
                 $daemonParams = $param['AbeilleSerialPort' . $nb] . ' ' . $logLevel . ' ' . $param['IpWifiZigate' . $nb];
                 $daemonLog = " >>" . $logDir . "AbeilleSocat" . $nb . '.log 2>&1';
-                $cmd = $nohup . " " . $php . " " . $daemonDir . $daemonPhp . " " .$daemonParams . $daemonLog;
+                $cmd = $nohup . " " . $php . " " . $daemonDir . $daemonPhp . " " . $daemonParams . $daemonLog;
                 break;
             default:
                 $cmd = "No daemon conf for " . $daemonFile;
@@ -466,7 +466,8 @@ class AbeilleTools
     /**
      * @param $zigateNumber
      */
-    public static function checkWifi($zigateNumber){
+    public static function checkWifi($zigateNumber)
+    {
         exec("command -v socat", $out, $ret);
         if ($ret != 0) {
             log::add('Abeille', 'error', 'socat n\'est  pas installé. zigate Wifi inutilisable. Installer socat depuis la partie wifi zigate de la page de configuration');
@@ -474,7 +475,7 @@ class AbeilleTools
             message::add("Abeille", "Erreur, socat n\'est  pas installé. zigate Wifi inutilisable. Installer socat depuis la partie wifi zigate de la page de configuration");
 
         } else {
-            log::add('Abeille', 'debug', __CLASS__.'::'.__FUNCTION__.' L:'.__LINE__. 'Zigate Wifi active trouvée, socat trouvé');
+            log::add('Abeille', 'debug', __CLASS__ . '::' . __FUNCTION__ . ' L:' . __LINE__ . 'Zigate Wifi active trouvée, socat trouvé');
         }
 
     }
@@ -519,6 +520,16 @@ class AbeilleTools
 
     }
 
+    /**
+     * simple log function, extended in AbeilleDebug
+     *
+     * @param string $loglevel
+     * @param string $message
+     */
+    function deamonlog($loglevel = 'NONE', $message = "")
+    {
+        log::add('Abeille', $loglevel, $message);
+    }
 
 }
 

--- a/resources/AbeilleDeamon/lib/AbeilleTools.php
+++ b/resources/AbeilleDeamon/lib/AbeilleTools.php
@@ -518,6 +518,8 @@ class AbeilleTools
         return false;
 
     }
+
+
 }
 
 ?>


### PR DESCRIPTION
de l'organisation dans cette PR:
- Déplacement de la classe AbeilleCmd dans le fichier AbeilleCmd.class.php
- Déplacement des daemons dans le repertoires AbeilleDaemon
- AbeilleTools: utilisation de variables de classes pour ne pas repeter dans chaque fonction.
- logs: je n'ai pas modifié l'utilisation des logs, je n'ai pas changé de log::add en logMessage, ni l'inverse. A voir comment, vous voulez gerer ce point.
- 

Ces modifications ont eu un gros impact sur les include, a surveiller donc. Je n'ai pas d 'alerte a ce sujet mais je n'utilise pas tout ce que vous avez mis en place.

tests fait avec une zigate usb en 3.1c (prod) et une autre en 3.1D (dev).

il reste a voir le cas de AbeilleDebug.class, actuellement quelques classes etendent AbeilleDebug.
Actuellement, les infos envoyées dans daemonlog ne sont pas affichées si isEnable est faux.
AbeilleCmd.process.class est la seule classe a utiliser AbeilleDebug.php
Ne faudrait t'il pas reintegrer AbeilleDebug dans AbeilleTools avec un switch pour basculer d'un mode à l'autre ?
j'ai préparé le terrain pour avoir une fonction daemonlog dans AbeilleTools.

Egalement ne faudrait t il pas faire disparaître les références a du MQTT dans le nom des fonctions, ce n'est plus parlant et pourrait causer des incompréhensions ?
