### PR TITLE
Daemons: empecher les demarrages de daemon en doublon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
+.idea/sonarlint/
 
 ## Plugin-specific files:
 

--- a/core/class/AbeilleParser.class.php
+++ b/core/class/AbeilleParser.class.php
@@ -137,7 +137,7 @@
             logSetConf("AbeilleParser.log");
 
             if ($this->debug["AbeilleParserClass"]) $this->deamonlog("debug", "AbeilleParser constructor");
-            $this->parameters_info = Abeille::getParameters();
+            $this->parameters_info = AbeilleTools::getParameters();
 
                         // $this->requestedlevel = $argv[7];
             $this->requestedlevel = '' ? 'none' : $argv[1];

--- a/desktop/php/Abeille.php
+++ b/desktop/php/Abeille.php
@@ -14,7 +14,7 @@ $eqLogics = eqLogic::byType('Abeille');
 
 $zigateNb = config::byKey('zigateNb', 'Abeille', '1');
 
-$parametersAbeille = Abeille::getParameters();
+$parametersAbeille = AbeilleTools::getParameters();
 
 $outils = array(
     'health'    => array( 'bouton'=>'bt_healthAbeille',         'icon'=>'fa-medkit',        'text'=>'{{Santé}}' ),
@@ -50,16 +50,16 @@ if (file_exists($dbgFile)) {
 
 			<!-- Icones de toutes les abeilles  -->
 			<?php include '020_AbeilleMesAbeillesPart.php'; ?>
-				
+
 			<legend><i class="fa fa-cogs"></i> {{Appliquer les commandes sur la selection}}</legend>
 			<div class="form-group" style="background-color: rgba(var(--defaultBkg-color), var(--opacity)) !important; padding-left: 10px">
-				
+
 				<!-- Gestion des groupes et des scenes  -->
 				<?php include '030_AbeilleGroupPart.php'; ?>
-				
+
 				<!-- Gestion des groupes et des scenes  -->
 				<?php include '040_AbeilleScenePart.php'; ?>
-			
+
 			</div>
 
 			<!-- Gestion des ghosts / remplacement d equipements  -->
@@ -67,7 +67,7 @@ if (file_exists($dbgFile)) {
 
 			<!-- Gestion des parametres Zigate -->
 			<?php include '060_AbeilleZigatePart.php'; ?>
-			
+
 			<!-- Affichage des details zigate  -->
 			<?php include '070_AbeilleDetailsPart.php'; ?>
 
@@ -75,12 +75,12 @@ if (file_exists($dbgFile)) {
 			<?php include '080_AbeilleZoneDevPart.php'; ?>
 
 		</div> <!-- Fin - Barre d outils horizontale  -->
-	
+
 	</form>
 
     <!-- Affichage des informations d un equipement - tab : Equipement / Param / Commandes  -->
     <div class="col-xs-12 eqLogic" style="display: none;">
-	
+
         <!-- Affichage de la zone developpeur  -->
         <?php include '100_AbeilleEntete.php'; ?>
 

--- a/resources/AbeilleDeamon/AbeilleCmd.php
+++ b/resources/AbeilleDeamon/AbeilleCmd.php
@@ -31,6 +31,16 @@
     // ***********************************************************************************************
     // exemple d appel
     // php AbeilleCmd.php debug
+    //check already running
+    $parameters = AbeilleTools::getParameters();
+    $running = AbeilleTools::getRunningDaemons();
+    $daemons= AbeilleTools::diffExpectedRunningDaemons($parameters,$running);
+    logMessage('info', 'status des daemons: '.json_encode($daemons));
+    #Two at least expected,the original and this one
+    if ($daemons["cmd"] > 1){
+        logMessage('error', 'Le daemon est déja lancé! '.json_encode($daemons));
+        exit(3);
+    }
 
     try {
         $AbeilleCmdQueue = new AbeilleCmdQueue($argv[1]);

--- a/resources/AbeilleDeamon/AbeilleInterrogate.php
+++ b/resources/AbeilleDeamon/AbeilleInterrogate.php
@@ -56,6 +56,8 @@
     $dest = $argv[1];
     $addressShort = $argv[2];
 
+
+
     while ( time() < $timeEnd ) {
         Abeille::publishMosquitto( queueKeyAbeilleToCmd, priorityInterrogation, "Cmd".$dest."/Ruche/IEEE_Address_request", "address=".$addressShort."&shortAddress=".$addressShort );
         echo ".";

--- a/resources/AbeilleDeamon/AbeilleParser.php
+++ b/resources/AbeilleDeamon/AbeilleParser.php
@@ -160,12 +160,22 @@
     $allErrorCode = $event + $zdpCode + $apsCode + $nwkCode + $macCode;
 
 
- 
+
     // ***********************************************************************************************
     // MAIN
     // ***********************************************************************************************
     // exemple d appel
     // php AbeilleParser.php /dev/ttyUSB0 127.0.0.1 1883 jeedom jeedom 0 debug
+    //check already running
+    $parameters = AbeilleTools::getParameters();
+    $running = AbeilleTools::getRunningDaemons();
+    $daemons= AbeilleTools::diffExpectedRunningDaemons($parameters,$running);
+    logMessage('info', 'status des daemons: '.json_encode($daemons));
+    #Two at least expected,the original and this one
+    if ($daemons["parser"] > 1){
+        logMessage('error', 'Le daemon est déja lancé! '.json_encode($daemons));
+        exit(3);
+    }
 
     try {
         // On crée l objet AbeilleParser

--- a/resources/AbeilleDeamon/AbeilleSerialRead.php
+++ b/resources/AbeilleDeamon/AbeilleSerialRead.php
@@ -58,6 +58,17 @@
         exit(3);
     }
 
+    //check already running
+    $parameters = AbeilleTools::getParameters();
+    $running = AbeilleTools::getRunningDaemons();
+    $daemons= AbeilleTools::diffExpectedRunningDaemons($parameters,$running);
+    logMessage('info', 'status des daemons: '.json_encode($daemons));
+    #Two at least expected,the original and this one
+    if ($daemons["serialRead".$abeilleNb] > 1){
+        logMessage('error', 'Le daemon est déja lancé! '.json_encode($daemons));
+        exit(3);
+    }
+
     $queueKeySerieToParser = msg_get_queue(queueKeySerieToParser);
 
     exec(system::getCmdSudo().' chmod 777 '.$serial.' >/dev/null 2>&1');

--- a/resources/AbeilleDeamon/AbeilleSocat.php
+++ b/resources/AbeilleDeamon/AbeilleSocat.php
@@ -43,9 +43,20 @@
         exit(2);
     }
 
-    /* Now we can extract network number to properly identify log file. */
+     /* Now we can extract network number to properly identify log file. */
     $abeilleNb = (int)substr($serial, 11); // '/dev/zigateX' => Zigate number X (ex: 1)
     logSetConf("AbeilleSocat".$abeilleNb.".log"); // Log to file with line nb check
+
+    //check already running
+    $parameters = AbeilleTools::getParameters();
+    $running = AbeilleTools::getRunningDaemons();
+    $daemons= AbeilleTools::diffExpectedRunningDaemons($parameters,$running);
+    logMessage('info', 'status des daemons: '.json_encode($daemons));
+    #Two at least expected,the original and this one
+    if ($daemons["socat".$abeilleNb] > 1){
+        logMessage('error', 'Le daemon est déja lancé! '.json_encode($daemons));
+        exit(3);
+    }
 
     $nohup 	= "/usr/bin/nohup";
     $sudo   = "/usr/bin/sudo";

--- a/resources/AbeilleDeamon/lib/AbeilleTools.php
+++ b/resources/AbeilleDeamon/lib/AbeilleTools.php
@@ -272,6 +272,31 @@ class AbeilleTools
     }
 
     /**
+     * Return an array with zigate configuration, used by daemon info and daemons
+     *
+     * @return array
+     */
+    public static function getParameters()
+    {
+        $return = array();
+        $return['parametersCheck'] = 'ok'; // Ces deux variables permettent d'indiquer la validité des données.
+        $return['parametersCheck_message'] = "";
+
+        //Most Fields are defined with default values
+        $return['AbeilleParentId'] = config::byKey('AbeilleParentId', 'Abeille', '1', 1);
+        $return['zigateNb'] = config::byKey('zigateNb', 'Abeille', '1', 1);
+
+        for ($i = 1; $i <= $return['zigateNb']; $i++) {
+            $return['AbeilleType' . $i] = config::byKey('AbeilleType' . $i, 'Abeille', 'none', 1);
+            $return['AbeilleSerialPort' . $i] = config::byKey('AbeilleSerialPort' . $i, 'Abeille', 'none', 1);
+            $return['IpWifiZigate' . $i] = config::byKey('IpWifiZigate' . $i, 'Abeille', '192.168.0.1', 1);
+            $return['AbeilleActiver' . $i] = config::byKey('AbeilleActiver' . $i, 'Abeille', 'N', 1);
+        }
+
+        return $return;
+    }
+
+    /**
      * CheckAlldeamones and send systemMessage to zigateX if needed
      *
      * @param $parameters


### PR DESCRIPTION
Contrôle des demons en cours avant le lancement du daemon: AbeilleSerial, AbeilleCmd, AbeilleParser, AbeilleSocat
je ne connais pas l'utilisation d'AbeilleInterrogate et donc je n'ai pas mis ce contrôle.

déplacement de la fonction utilitaire getParameters dans la classe AbeilleTools pour que les demons y aient accès.