### PR TITLE
Ajout Télérupteur Legrand 16AX resolve #1454

### DIFF
--- a/core/config/devices/Teleruptor/Teleruptor.json
+++ b/core/config/devices/Teleruptor/Teleruptor.json
@@ -1,0 +1,31 @@
+{
+  "Teleruptor": {
+    "nameJeedom": "Legrand Teleruptor",
+    "timeout": "60",
+    "Categorie": {
+      "automatism": "1"
+    },
+    "configuration": {
+      "uniqId": "5c07c766206sdztggg7ceiu",
+      "icone": "Teleruptor",
+      "mainEP": "#EP#"
+    },
+    "Commandes": {
+      "include1": "nom",
+      "include2": "societe",
+      "include3": "SW",
+      "include4": "etat",
+      "include8": "On",
+      "include9": "Off",
+      "include10": "Toggle",
+      "include19": "getEtat",
+      "include21": "getManufacturerName",
+      "include22": "getModelIdentifier",
+      "include23": "getSWBuild",
+      "include24": "Identify",
+      "include25": "Group-Membership",
+      "include26": "BindToZigateEtat",
+      "include28": "setReportEtat"
+    }
+  }
+}


### PR DESCRIPTION
J'ai créé ce JSON, ça fonctionne, mais pas parfaitement.
on, off et état sont ok, mais quand on change l'état de la lumière par l'interrupteur l'état ne remonte pas.
Je suppose que c'est la commande `"include26": "BindToZigateEtat"`, mais je ne suis pas certain.
Je n'ai pas non plus la remontée de la consommation, mais je pense que c'est parce que je ne l'ai pas configuré du tout. N'ayant pas encore de prise je n'ai pas d'exemple chez moi pour comparer.

Je suis preneur d'idées, conseils,… pour améliorer ça.