### PR TITLE
Correction nom image dans le modele diy-amp-router

### DIFF
--- a/core/config/devices/diy-amp-router/diy-amp-router.json
+++ b/core/config/devices/diy-amp-router/diy-amp-router.json
@@ -7,7 +7,7 @@
     },
     "configuration": {
       "uniqId": "20210323_1705",
-      "icone": "Diy-amp-router",
+      "icone": "diy-amp-router",
       "mainEP": "01"
     },
     "Commandes": {


### PR DESCRIPTION
Correction en retirant la majuscule
Le node_Diy-amp-router peut être supprimé. Ne conserver que celui sans majuscule