### PR TITLE
Ajout du report de l'état de la prise n°1, sur la multiprise Silvercrest / Lidl #1848

### DIFF
--- a/core/config/devices/TS011F__TZ3000_vzopcetz/TS011F__TZ3000_vzopcetz.json
+++ b/core/config/devices/TS011F__TZ3000_vzopcetz/TS011F__TZ3000_vzopcetz.json
@@ -28,8 +28,10 @@
             "include7 2": "Toggle1",
             "include7 2 2": "Toggle2",
             "include8": "getEtat",
-            "include9": "getManufacturerName",
-            "include10": "getModelIdentifier"
+            "include9": "BindToZigateEtat",
+            "include10":"setReportEtat",
+            "include11": "getManufacturerName",
+            "include12": "getModelIdentifier"
         }
     }
 }


### PR DESCRIPTION
Relatif à https://github.com/KiwiHC16/Abeille/issues/1848

Ajout du report de l'état de la prise n°1, sur la multiprise Silvercrest / Lidl, lorsqu'elle est allumée/éteinte depuis le bouton physique.