### PR TITLE
Correction perte choix historisation/affichage + ..

### DIFF
--- a/core/config/devices/PSE03-v1.1.0/notes.txt
+++ b/core/config/devices/PSE03-v1.1.0/notes.txt
@@ -1,0 +1,11 @@
+[2021-06-28 06:32:51]   ModelIdentifier='PSE03-v1.1.0', trimmed='PSE03-v1.1.0'
+
+[2021-06-28 06:40:19] Abeille1, Type=8043/Simple descriptor response, SQN=0A, Status=00, Addr=A2E4, Length=14, EP=01, ProfId=0104/ZigBee Home Automation (ZHA), DevId=0403/IAS Warning Device, BitField=00
+[2021-06-28 06:40:19]   InClusterCount=5
+[2021-06-28 06:40:19]   InCluster=0000 => General-Basic
+[2021-06-28 06:40:19]   InCluster=0001 => General-Power Config
+[2021-06-28 06:40:19]   InCluster=0009 => General-Alarms
+[2021-06-28 06:40:19]   InCluster=0500 => Security & Safety-IAS Zone
+[2021-06-28 06:40:19]   InCluster=0502 => Security & Safety-IAS WD
+[2021-06-28 06:40:19]   OutClusterCount=00
+[2021-06-28 06:40:19]   OutCluster=0019 => General-OTA

--- a/core/config/devices/TRADFRIonoffswitch/notes.txt
+++ b/core/config/devices/TRADFRIonoffswitch/notes.txt
@@ -33,7 +33,8 @@ MAC capa: 80
 - Clust 1000: FFFD
 - Clust FC7C:
 
-
+Binding
+=======
 https://www.zigbee2mqtt.io/devices/E1743.html
 
 Binding #
@@ -41,6 +42,9 @@ The E1743 can be bound to groups using binding. It can only be bound to 1 group 
 
 By default this remote is bound to the default bind group which you first have to unbind it from.
 Right before executing the commands make sure to wake up the device by pressing a button on it.
+
+Lot's of issues around bind/unbind. 
+https://github.com/Koenkk/zigbee2mqtt/issues/2924
 
 About configure reporting
 =========================

--- a/core/config/devices/plug.maeu01/plug.maeu01.json
+++ b/core/config/devices/plug.maeu01/plug.maeu01.json
@@ -1,13 +1,14 @@
 {
   "plug.maeu01": {
     "nameJeedom": "Aqara SmartPlug",
+    "manufacturer": "Xiaomi",
+    "model": "SP-EUC01 ?",
     "timeout": "60",
     "Comment": "https://github.com/KiwiHC16/Abeille/issues/1578",
     "Categorie": {
       "automatism": "1"
     },
     "configuration": {
-      "uniqId": "20210127_2358",
       "icone": "plug.maeu01",
       "mainEP": "#EP#"
     },

--- a/desktop/modal/AbeilleHealth.modal.php
+++ b/desktop/modal/AbeilleHealth.modal.php
@@ -90,7 +90,7 @@ Démons:
             <?php } ?> -->
             <th class="header" data-toggle="tooltip" title="Trier par">{{Dernière communication}}</th>
             <th class="header" data-toggle="tooltip" title="Trier par">{{Depuis (h)}}</th>
-            <th class="header" data-toggle="tooltip" title="Trier par">{{Date création}}</th>
+            <th class="header" data-toggle="tooltip" title="Trier par">{{Dernier LQI}}</th>
         </tr>
     </thead>
     <tbody>
@@ -109,18 +109,18 @@ Démons:
             // ID
             echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$eqLogic->getId().'</span></td>';
 
-            $parts = explode("/", $eqLogic->getLogicalId());
+            list($net, $addr) = explode("/", $eqLogic->getLogicalId());
 
             // Ruche
-            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$parts[0].'</span></td>';
+            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$net.'</span></td>';
 
             // Short Address
-            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$parts[1].'</span></td>';
+            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$addr.'</span></td>';
 
             /* Extended address/IEEE
                If present in config, taking it.
                If not, asking IEEE adress */
-            if ( $eqLogic->getConfiguration('icone') == "remotecontrol" ) {
+            if ($eqLogic->getConfiguration('icone') == "remotecontrol") {
                 $addrIEEE = "-";
             } else {
                 $addrIEEE = $eqLogic->getConfiguration('IEEE', 'none');
@@ -131,8 +131,8 @@ Démons:
                         $addrIEEE = strtoupper($commandIEEE->execCmd());
                     }
                 }
-                if (strlen($addrIEEE) > 2 ) {
-                    if ( array_key_exists($addrIEEE, $IEEE_Table) ) {
+                if (strlen($addrIEEE) > 2) {
+                    if (array_key_exists($addrIEEE, $IEEE_Table)) {
                         $IEEE_Table[$addrIEEE] += 1;
                     }
                     else {
@@ -179,9 +179,9 @@ Démons:
             // }
 
             // Last comm.
-            if ( $eqLogic->getConfiguration('icone') == "remotecontrol" ) {
+            if ($eqLogic->getConfiguration('icone') == "remotecontrol") {
                 $lastComm = '<span class="label label-info" style="font-size: 1em; cursor: default;">-</span>';
-            } else if ( strlen($eqLogic->getStatus('lastCommunication'))>2 ) {
+            } else if (strlen($eqLogic->getStatus('lastCommunication'))>2) {
                 $lastComm = '<span class="label label-info" style="font-size: 1em; cursor: default;">'.$eqLogic->getStatus('lastCommunication').'</span>';
             } else
                 $lastComm = '<span class="label label-warning" style="font-size: 1em; cursor: default;">No message received !!</span>';
@@ -189,14 +189,23 @@ Démons:
 
             // Depuis
             $Depuis = '<span class="label label-info" style="font-size: 1em; cursor: default;">'.(floor((time() - strtotime($eqLogic->getStatus('lastCommunication'))) / 3600)).'</span>';
-             if ( $eqLogic->getConfiguration('icone') == "remotecontrol" ) {
+             if ($eqLogic->getConfiguration('icone') == "remotecontrol") {
                  $Depuis = '<span class="label label-info" style="font-size: 1em; cursor: default;">-</span>';
              }
             //if ($eqLogic->getStatus('state') == '-') { $Depuis = '<span class="label label-info" style="font-size: 1em; cursor: default;">-</span>'; }
             echo '<td>'.$Depuis.'</td>';
 
-            // Date Creation
-            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$eqLogic->getConfiguration('createtime').'</span></td></tr>';
+            // Last LQI
+            if ($addr == "0000")
+                $lastLqi = "-";
+            else {
+                $lqiCmd = $eqLogic->getCmd('info', 'Link-Quality');
+                if (is_object($lqiCmd))
+                    $lastLqi = $lqiCmd->execCmd();
+                else
+                    $lastLqi = "?";
+            }
+            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$lastLqi.'</span></td></tr>';
         }
     ?>
     </tbody>

--- a/docs/fr_FR/Changelog.rst
+++ b/docs/fr_FR/Changelog.rst
@@ -1,9 +1,6 @@
 ChangeLog
 =========
 
-210715-BETA-1
-----------
-
 - ATTENTION: Format JSON des fichiers de commande modifié !
 - Osram classic B40TW: support préliminaire.
 - Xiaomi Luminosite: Ajout pourcentage batterie basé sur retour tension (#1166).
@@ -30,6 +27,9 @@ ChangeLog
 - JSON: Syntaxe commandes modifiée. Type 'execAtCreationDelay' changé en 'nombre' et non plus 'string'.
   Devrait corriger le pb de config de certains equipements à l'inclusion.
 - Correction perte categorie & icone si equipement se réannonce.
+- Correction perte état historisation & affichage des commandes si equipement se réannonce.
+- Correction mise-à-jour commandes IEEE-Addr, Short-Addr & Power-Source sur réannonce.
+- Page santé: Ajout "dernier LQI" à la place de "Date de création".
 
 210704-STABLE-1
 ----------


### PR DESCRIPTION
- Correction perte état historisation & affichage des commandes si equipement se réannonce.
- Correction mise-à-jour commandes IEEE-Addr, Short-Addr & Power-Source sur réannonce.
- Page santé: Ajout "dernier LQI" à la place de "Date de création".
