### PR TITLE
Improve device identification

### DIFF
--- a/core/class/AbeilleParser.class.php
+++ b/core/class/AbeilleParser.class.php
@@ -560,6 +560,16 @@
                 if ($missing != '') {
                     parserLog('debug', '  Requesting '.$missingTxt.' from EP '.$eq['epFirst']);
                     $this->msgToCmd("Cmd".$net."/".$addr."/readAttribute", "ep=".$eq['epFirst']."&clustId=0000&attrId=".$missing);
+
+                    // jbromain: we check if EP '01' exists BUT is not the first EP
+                    // If so, we will request model and/or manufacturer from both EPs (the first one AND 01)
+                    // Use case: Sonoff smart plug s26R2ZB (several EPs but the first one is not the main and does not implement model nor manufacturer)
+                    // TODO We should maybe query ALL end points ? For now I try to limit requests
+                    $epArr = explode('/', $eq['epList']);
+                    if ($eq['epFirst'] != '01' && in_array('01', $epArr)) {
+                        parserLog('debug', '  Requesting '.$missingTxt.' from EP 01 too (not the first but exits)');
+                        $this->msgToCmd("Cmd".$net."/".$addr."/readAttribute", "ep=01&clustId=0000&attrId=".$missing);
+                    }
                 }
             }
 


### PR DESCRIPTION
### Références
Issue #2221 

### Fonctionnement précédent
Lors de l'inclusion d'un périphérique, en phase d'identification, Abeille interroge le premier EndPoint pour obtenir le fabricant et le modèle de l'équipement.

Or, certains périphériques (rares) n'implémentent pas le cluster 0000 sur le premier EndPoint mais sur un autre (ex: Sonoff Smart Plug #2221)

### Amélioration proposée
Si le périphérique a plusieurs EndPoints, la modification proposée consiste à interroger l'EP 01 s'il existe, en plus du premier EndPoint.

### Remarque
Cette solution répond au besoin du périphérique Sonoff Smart Plug, mais il est possible qu'on rencontre le problème avec d'autres; il sera alors peut-être nécessaire d'interroger systématiquement tous les EndPoints de l'équipement en phase d'identification (pour le moment j'ai souhaité limiter les requêtes; je peux faire la modif sans attendre que le cas se présente si vous préférez).