### PR TITLE
Modeles SML002+WarningDevice + fixes + ...

### DIFF
--- a/.tools/update_json.php
+++ b/.tools/update_json.php
@@ -282,8 +282,37 @@
                     $commands2["etat inter ".$x] = $cmdArr;
                     $devUpdated = true;
                     echo "  Cmd '".$cmdFName."' UPDATED.\n";
-                }
-                else if (($cmdFName == "getEtat") && $oldSyntax) {
+                } else if ((($cmdFName == "etatEp01out") || ($cmdFName == "etatEp02out") || ($cmdFName == "etatEp03out") || ($cmdFName == "etatEp04out")
+                || ($cmdFName == "etatEp05out") || ($cmdFName == "etatEp06out") || ($cmdFName == "etatEp07out") || ($cmdFName == "etatEp08out"))
+                        && $oldSyntax) {
+                    $ep = hexdec(substr($cmdFName, 6, 2));
+                    $cmdArr = Array(
+                        "use" => "zb-0006-OnOff",
+                        "params" => "ep=".$ep,
+                        "subType" => "binary",
+                        // "template" => "door",
+                        "genericType" => "SWITCH_STATE",
+                        "isVisible" => 1
+                    );
+                    $commands2["Digital Output ".$ep] = $cmdArr;
+                    $devUpdated = true;
+                    echo "  Cmd '".$cmdFName."' UPDATED.\n";
+                } else if ((($cmdFName == "etatEp01in") || ($cmdFName == "etatEp02in") || ($cmdFName == "etatEp03in") || ($cmdFName == "etatEp04in")
+                || ($cmdFName == "etatEp05in") || ($cmdFName == "etatEp06in") || ($cmdFName == "etatEp07in") || ($cmdFName == "etatEp08in"))
+                        && $oldSyntax) {
+                    $ep = hexdec(substr($cmdFName, 6, 2));
+                    $cmdArr = Array(
+                        "use" => "zb-0006-OnOff",
+                        "params" => "ep=".$ep,
+                        "subType" => "binary",
+                        // "template" => "door",
+                        "genericType" => "SWITCH_STATE",
+                        "isVisible" => 1
+                    );
+                    $commands2["Digital Input ".$ep] = $cmdArr;
+                    $devUpdated = true;
+                    echo "  Cmd '".$cmdFName."' UPDATED.\n";
+                } else if (($cmdFName == "getEtat") && $oldSyntax) {
                     $cmdArr = Array(
                         "use"=> "zbReadAttribute",
                         "params"=> "clustId=0006&attrId=0000"

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -2200,9 +2200,10 @@ if (0) {
             foreach ($msg['attributes'] as $attr) {
                 $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $attr['name']);
                 if (!is_object($cmdLogic)) {
-                    log::add('Abeille', 'debug', "  Unknown Jeedom command '".$attr['name']."'");
+                    log::add('Abeille', 'debug', "  Unknown Jeedom command logicId='".$attr['name']."'");
                 } else {
-                    log::add('Abeille', 'debug', "  ".$attr['name']." => ".$attr['value']);
+                    $cmdName = $cmdLogic->getName();
+                    log::add('Abeille', 'debug', "  '".$cmdName."' (".$attr['name'].") => ".$attr['value']);
                     $eqLogic->checkAndUpdateCmd($cmdLogic, $attr['value']);
 
                     // Check if any action cmd must be executed triggered by this update
@@ -2768,7 +2769,8 @@ if (0) {
                         Other reasons to generate message ?
                     */
                     if ($eqLogic->getIsEnable() == 1) {
-                        log::add('Abeille', 'debug', '  Device is already enabled. Doing nothing.');
+                        // log::add('Abeille', 'debug', '  Device is already enabled. Doing nothing.');
+                        log::add('Abeille', 'debug', '  Device is already enabled.');
                         // return; // Doing nothing on re-announce
                     } else
                     message::add("Abeille", "'".$eqHName."' s'est réannoncé. Mise-à-jour en cours.", '');

--- a/core/config/commands/OBSOLETE/etatEp01out.json
+++ b/core/config/commands/OBSOLETE/etatEp01out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp01out": {
+        "isVisible": 1,
+        "name": "Digital Output 1",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-01-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp02in.json
+++ b/core/config/commands/OBSOLETE/etatEp02in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp02in": {
+        "isVisible": 1,
+        "name": "Digital Input 2",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-02-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp02out.json
+++ b/core/config/commands/OBSOLETE/etatEp02out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp02out": {
+        "isVisible": 1,
+        "name": "Digital Output 2",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-02-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp03in.json
+++ b/core/config/commands/OBSOLETE/etatEp03in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp03in": {
+        "isVisible": 1,
+        "name": "Digital Input 3",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-03-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp03out.json
+++ b/core/config/commands/OBSOLETE/etatEp03out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp03out": {
+        "isVisible": 1,
+        "name": "Digital Output 3",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-03-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp04in.json
+++ b/core/config/commands/OBSOLETE/etatEp04in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp04in": {
+        "isVisible": 1,
+        "name": "Digital Input 4",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-04-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp04out.json
+++ b/core/config/commands/OBSOLETE/etatEp04out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp04out": {
+        "isVisible": 1,
+        "name": "Digital Output 4",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-04-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp05in.json
+++ b/core/config/commands/OBSOLETE/etatEp05in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp05in": {
+        "isVisible": 1,
+        "name": "Digital Input 5",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-05-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp05out.json
+++ b/core/config/commands/OBSOLETE/etatEp05out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp05out": {
+        "isVisible": 1,
+        "name": "Digital Output 5",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-05-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp06in.json
+++ b/core/config/commands/OBSOLETE/etatEp06in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp06in": {
+        "isVisible": 1,
+        "name": "Digital Input 6",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-06-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp06out.json
+++ b/core/config/commands/OBSOLETE/etatEp06out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp06out": {
+        "isVisible": 1,
+        "name": "Digital Output 6",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-06-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp07in.json
+++ b/core/config/commands/OBSOLETE/etatEp07in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp07in": {
+        "isVisible": 1,
+        "name": "Digital Input 7",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-07-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp07out.json
+++ b/core/config/commands/OBSOLETE/etatEp07out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp07out": {
+        "isVisible": 1,
+        "name": "Digital Output 7",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-07-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp08.json
+++ b/core/config/commands/OBSOLETE/etatEp08.json
@@ -1,0 +1,16 @@
+{
+    "etatEp08": {
+        "isVisible": 1,
+        "name": "etat 8",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "template": "light",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-08-0000",
+        "genericType": "LIGHT_STATE_BOOL"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp08in.json
+++ b/core/config/commands/OBSOLETE/etatEp08in.json
@@ -1,0 +1,15 @@
+{
+    "etatEp08in": {
+        "isVisible": 1,
+        "name": "Digital Input 8",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-08-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/OBSOLETE/etatEp08out.json
+++ b/core/config/commands/OBSOLETE/etatEp08out.json
@@ -1,0 +1,15 @@
+{
+    "etatEp08out": {
+        "isVisible": 1,
+        "name": "Digital Output 8",
+        "isHistorized": "1",
+        "subType": "binary",
+        "invertBinary": "0",
+        "configuration": {
+            "visibilityCategory": "All"
+        },
+        "type": "info",
+        "logicalId": "0006-08-0000",
+        "genericType": "SWITCH_STATE"
+    }
+}

--- a/core/config/commands/zb-0405-MeasuredValue.json
+++ b/core/config/commands/zb-0405-MeasuredValue.json
@@ -8,7 +8,7 @@
         "template": "hydro3IMG",
         "configuration": {
             "calculValueOffset": "#value#\/100",
-            "historizeRound": "1"
+            "historizeRound": "0"
         },
         "type": "info",
         "logicalId": "0405-#EP#-0000",

--- a/core/config/devices/1-digital-input/1-digital-input.json
+++ b/core/config/devices/1-digital-input/1-digital-input.json
@@ -10,7 +10,13 @@
         },
         "type": "1-digital-input",
         "commands": {
-            "include2": "etatEp02in",
+            "Digital Input 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 2": {
                 "use": "zbReadAttribute",
                 "params": "ep=02&clustId=0006&attrId=0000"

--- a/core/config/devices/4-digital-input/4-digital-input.json
+++ b/core/config/devices/4-digital-input/4-digital-input.json
@@ -10,22 +10,46 @@
         },
         "type": "4-digital-input",
         "commands": {
-            "include2": "etatEp02in",
+            "Digital Input 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 2": {
                 "use": "zbReadAttribute",
                 "params": "ep=02&clustId=0006&attrId=0000"
             },
-            "include3": "etatEp03in",
+            "Digital Input 3": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=3",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 3": {
                 "use": "zbReadAttribute",
                 "params": "ep=03&clustId=0006&attrId=0000"
             },
-            "include4": "etatEp04in",
+            "Digital Input 4": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=4",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 4": {
                 "use": "zbReadAttribute",
                 "params": "ep=04&clustId=0006&attrId=0000"
             },
-            "include5": "etatEp05in",
+            "Digital Input 5": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=5",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 5": {
                 "use": "zbReadAttribute",
                 "params": "ep=05&clustId=0006&attrId=0000"

--- a/core/config/devices/7-digital-input/7-digital-input.json
+++ b/core/config/devices/7-digital-input/7-digital-input.json
@@ -10,37 +10,79 @@
         },
         "type": "7-digital-input",
         "commands": {
-            "include2": "etatEp02in",
+            "Digital Input 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 2": {
                 "use": "zbReadAttribute",
                 "params": "ep=02&clustId=0006&attrId=0000"
             },
-            "include3": "etatEp03in",
+            "Digital Input 3": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=3",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 3": {
                 "use": "zbReadAttribute",
                 "params": "ep=03&clustId=0006&attrId=0000"
             },
-            "include4": "etatEp04in",
+            "Digital Input 4": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=4",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 4": {
                 "use": "zbReadAttribute",
                 "params": "ep=04&clustId=0006&attrId=0000"
             },
-            "include5": "etatEp05in",
+            "Digital Input 5": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=5",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 5": {
                 "use": "zbReadAttribute",
                 "params": "ep=05&clustId=0006&attrId=0000"
             },
-            "include6": "etatEp06in",
+            "Digital Input 6": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=6",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 6": {
                 "use": "zbReadAttribute",
                 "params": "ep=06&clustId=0006&attrId=0000"
             },
-            "include7": "etatEp07in",
+            "Digital Input 7": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=7",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 7": {
                 "use": "zbReadAttribute",
                 "params": "ep=07&clustId=0006&attrId=0000"
             },
-            "include8": "etatEp08in",
+            "Digital Input 8": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=8",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Get-OnOffStatus 8": {
                 "use": "zbReadAttribute",
                 "params": "ep=08&clustId=0006&attrId=0000"

--- a/core/config/devices/8-digital-output/8-digital-output.json
+++ b/core/config/devices/8-digital-output/8-digital-output.json
@@ -10,38 +10,174 @@
         },
         "type": "8-digital-output",
         "commands": {
-            "On 1": { "use": "zbCmd-0006-On", "params": "ep=01", "isVisible": 1 },
-            "Off 1": { "use": "zbCmd-0006-Off", "params": "ep=01", "isVisible": 1 },
-            "Get-Etat 1": { "use": "zbReadAttribute", "params": "ep=01&clustId=0006&attrId=0000" },
-            "include1 1 1 1 1": "etatEp01out",
-            "On 2": { "use": "zbCmd-0006-On", "params": "ep=02", "isVisible": 1 },
-            "Off 2": { "use": "zbCmd-0006-Off", "params": "ep=02", "isVisible": 1 },
-            "Get-Etat 2": { "use": "zbReadAttribute", "params": "ep=02&clustId=0006&attrId=0000" },
-            "include2 1 1 1 1": "etatEp02out",
-            "On 3": { "use": "zbCmd-0006-On", "params": "ep=03", "isVisible": 1 },
-            "Off 3": { "use": "zbCmd-0006-Off", "params": "ep=03", "isVisible": 1 },
-            "Get-Etat 3": { "use": "zbReadAttribute", "params": "ep=03&clustId=0006&attrId=0000" },
-            "include3 1 1 1 1": "etatEp03out",
-            "On 4": { "use": "zbCmd-0006-On", "params": "ep=04", "isVisible": 1 },
-            "Off 4": { "use": "zbCmd-0006-Off", "params": "ep=04", "isVisible": 1 },
-            "Get-Etat 4": { "use": "zbReadAttribute", "params": "ep=04&clustId=0006&attrId=0000" },
-            "include4 1 1 1 1": "etatEp04out",
-            "On 5": { "use": "zbCmd-0006-On", "params": "ep=05", "isVisible": 1 },
-            "Off 5": { "use": "zbCmd-0006-Off", "params": "ep=05", "isVisible": 1 },
-            "Get-Etat 5": { "use": "zbReadAttribute", "params": "ep=05&clustId=0006&attrId=0000" },
-            "include5 1 1 1 1": "etatEp05out",
-            "On 6": { "use": "zbCmd-0006-On", "params": "ep=06", "isVisible": 1 },
-            "Off 6": { "use": "zbCmd-0006-Off", "params": "ep=06", "isVisible": 1 },
-            "Get-Etat 6": { "use": "zbReadAttribute", "params": "ep=06&clustId=0006&attrId=0000" },
-            "include6 1 1 1 1": "etatEp06out",
-            "On 7": { "use": "zbCmd-0006-On", "params": "ep=07", "isVisible": 1 },
-            "Off 7": { "use": "zbCmd-0006-Off", "params": "ep=07", "isVisible": 1 },
-            "Get-Etat 7": { "use": "zbReadAttribute", "params": "ep=07&clustId=0006&attrId=0000" },
-            "include7 1 1 1 1": "etatEp07out",
-            "On 8": { "use": "zbCmd-0006-On", "params": "ep=08", "isVisible": 1 },
-            "Off 8": { "use": "zbCmd-0006-Off", "params": "ep=08", "isVisible": 1 },
-            "Get-Etat 8": { "use": "zbReadAttribute", "params": "ep=08&clustId=0006&attrId=0000" },
-            "include8 1 1 1 1": "etatEp08out",
+            "On 1": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=01",
+                "isVisible": 1
+            },
+            "Off 1": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=01",
+                "isVisible": 1
+            },
+            "Get-Etat 1": {
+                "use": "zbReadAttribute",
+                "params": "ep=01&clustId=0006&attrId=0000"
+            },
+            "Digital Output 1": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=1",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 2": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=02",
+                "isVisible": 1
+            },
+            "Off 2": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=02",
+                "isVisible": 1
+            },
+            "Get-Etat 2": {
+                "use": "zbReadAttribute",
+                "params": "ep=02&clustId=0006&attrId=0000"
+            },
+            "Digital Output 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 3": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=03",
+                "isVisible": 1
+            },
+            "Off 3": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=03",
+                "isVisible": 1
+            },
+            "Get-Etat 3": {
+                "use": "zbReadAttribute",
+                "params": "ep=03&clustId=0006&attrId=0000"
+            },
+            "Digital Output 3": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=3",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 4": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=04",
+                "isVisible": 1
+            },
+            "Off 4": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=04",
+                "isVisible": 1
+            },
+            "Get-Etat 4": {
+                "use": "zbReadAttribute",
+                "params": "ep=04&clustId=0006&attrId=0000"
+            },
+            "Digital Output 4": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=4",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 5": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=05",
+                "isVisible": 1
+            },
+            "Off 5": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=05",
+                "isVisible": 1
+            },
+            "Get-Etat 5": {
+                "use": "zbReadAttribute",
+                "params": "ep=05&clustId=0006&attrId=0000"
+            },
+            "Digital Output 5": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=5",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 6": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=06",
+                "isVisible": 1
+            },
+            "Off 6": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=06",
+                "isVisible": 1
+            },
+            "Get-Etat 6": {
+                "use": "zbReadAttribute",
+                "params": "ep=06&clustId=0006&attrId=0000"
+            },
+            "Digital Output 6": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=6",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 7": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=07",
+                "isVisible": 1
+            },
+            "Off 7": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=07",
+                "isVisible": 1
+            },
+            "Get-Etat 7": {
+                "use": "zbReadAttribute",
+                "params": "ep=07&clustId=0006&attrId=0000"
+            },
+            "Digital Output 7": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=7",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 8": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=08",
+                "isVisible": 1
+            },
+            "Off 8": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=08",
+                "isVisible": 1
+            },
+            "Get-Etat 8": {
+                "use": "zbReadAttribute",
+                "params": "ep=08&clustId=0006&attrId=0000"
+            },
+            "Digital Output 8": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=8",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
             "Toggle 01": {
                 "use": "zbCmd-0006-Toggle",
                 "params": "ep=01",

--- a/core/config/devices/SML002/SML002.json
+++ b/core/config/devices/SML002/SML002.json
@@ -2,6 +2,7 @@
     "SML002": {
         "manufacturer": "Philips",
         "model": "9290019758",
+        "type": "Philips Hue motion sensor",
         "timeout": "60",
         "configuration": {
             "mainEP": "02",
@@ -11,20 +12,19 @@
         "category": {
             "security": "1"
         },
-        "type": "Philips Hue motion sensor",
         "commands": {
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },
 
             "include4 3 2": "Batterie-Hue",
-            "Bind-0001-ToZigate": {
+            "Bind 0001-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0001",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
-            "SetReporting-0001-0021": {
+            "SetReporting 0001-0021": {
                 "use": "zbConfigureReporting",
                 "params": "clustId=0001&attrType=20&attrId=0021&minInterval=0708&maxInterval=0E10&changeVal=",
                 "execAtCreation": "Yes",
@@ -32,15 +32,15 @@
             },
 
             "include4": "luminositeHue",
-            "Bind-0400-ToZigate": {
+            "Bind 0400-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0400",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
-            "SetReporting-0400-0000": {
+            "SetReporting 0400-0000": {
                 "use": "zbConfigureReporting",
-                "params": "clustId=0400&attrType=21&attrId=0000&minInterval=012C&maxInterval=0258&changeVal=",
+                "params": "clustId=0400&attrType=21&attrId=0000&minInterval=012C&maxInterval=0258&changeVal=0000",
                 "comment": "Reporting every 5 to 10mins",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 11
@@ -51,28 +51,28 @@
                 "isVisible": 1,
                 "isHistorized": 1
             },
-            "Bind-0402-ToZigate": {
+            "Bind 0402-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0402",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
-            "SetReporting-0402-0000": {
+            "SetReporting 0402-0000": {
                 "use": "zbConfigureReporting",
-                "params": "clustId=0402&attrType=29&attrId=0000&minInterval=012C&maxInterval=0258&changeVal=",
+                "params": "clustId=0402&attrType=29&attrId=0000&minInterval=012C&maxInterval=0258&changeVal=0000",
                 "comment": "Reporting every 5 to 10mins",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 12
             },
 
             "include3": "presence",
-            "Bind-0406-ToZigate": {
+            "Bind 0406-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0406",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
-             "SetReporting-0406-0000": {
+             "SetReporting 0406-0000": {
                 "use": "zbConfigureReporting",
                 "params": "clustId=0406&attrType=18&attrId=0000&minInterval=0000&maxInterval=0000&changeVal=",
                 "execAtCreation": "Yes",

--- a/core/config/devices/WarningDevice-EF-3.0/WarningDevice-EF-3.0.json
+++ b/core/config/devices/WarningDevice-EF-3.0/WarningDevice-EF-3.0.json
@@ -1,5 +1,9 @@
 {
     "WarningDevice-EF-3.0": {
+        "alternateIds": "WarningDevice,SRHMP-I1,TS0216__TYZB01_8scntis1",
+        "manufacturer": "Heiman",
+        "model": "HS2WD",
+        "type": "Heiman HS2WD warning device",
         "timeout": "60",
         "configuration": {
             "mainEP": "01",
@@ -8,7 +12,6 @@
         "category": {
             "automatism": "1"
         },
-        "type": "Alarm Smart Siren Heiman Siren : WarningDevice-EF-3.0",
         "commands": {
             "include4": "zb-0000-ZCLVersion",
             "include24": "Identify",
@@ -33,8 +36,23 @@
             "Get-SWBuildID": {
                 "use": "zbReadAttribute",
                 "params": "clustId=0000&attrId=4000"
+            },
+
+            "Test SOUND & FLASH": {
+                "use": "zbCmd-0502-StartWarning",
+                "params": "ep=01&mode=burglar",
+                "isVisible": "1"
+            },
+            "Test SOUND only": {
+                "use": "zbCmd-0502-StartWarning",
+                "params": "ep=01&mode=burglar&strobe=off",
+                "isVisible": "1"
+            },
+            "Test FLASH only": {
+                "use": "zbCmd-0502-StartWarning",
+                "params": "ep=01&mode=stop&strobe=on",
+                "isVisible": "1"
             }
-        },
-        "comment": "Draft"
+        }
     }
 }

--- a/core/config/devices/diy-mains-fault/diy-mains-fault.json
+++ b/core/config/devices/diy-mains-fault/diy-mains-fault.json
@@ -10,8 +10,17 @@
         },
         "type": "diy-mains-fault",
         "commands": {
-            "include2": "etatEp02in",
-            "Get-Etat 2": { "use": "zbReadAttribute", "params": "ep=02&clustId=0006&attrId=0000" }
+            "Digital Input 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "Get-Etat 2": {
+                "use": "zbReadAttribute",
+                "params": "ep=02&clustId=0006&attrId=0000"
+            }
         }
     }
 }

--- a/core/config/devices/fuel-tank-level/fuel-tank-level.json
+++ b/core/config/devices/fuel-tank-level/fuel-tank-level.json
@@ -10,14 +10,50 @@
         },
         "type": "fuel-tank-level",
         "commands": {
-            "include2": "etatEp02in",
-            "Get-Etat 2": { "use": "zbReadAttribute", "params": "ep=02&clustId=0006&attrId=0000" },
-            "include3": "etatEp03in",
-            "Get-Etat 3": { "use": "zbReadAttribute", "params": "ep=03&clustId=0006&attrId=0000" },
-            "include4": "etatEp04in",
-            "Get-Etat 4": { "use": "zbReadAttribute", "params": "ep=04&clustId=0006&attrId=0000" },
-            "include5": "etatEp05in",
-            "Get-Etat 5": { "use": "zbReadAttribute", "params": "ep=05&clustId=0006&attrId=0000" }
+            "Digital Input 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "Get-Etat 2": {
+                "use": "zbReadAttribute",
+                "params": "ep=02&clustId=0006&attrId=0000"
+            },
+            "Digital Input 3": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=3",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "Get-Etat 3": {
+                "use": "zbReadAttribute",
+                "params": "ep=03&clustId=0006&attrId=0000"
+            },
+            "Digital Input 4": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=4",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "Get-Etat 4": {
+                "use": "zbReadAttribute",
+                "params": "ep=04&clustId=0006&attrId=0000"
+            },
+            "Digital Input 5": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=5",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "Get-Etat 5": {
+                "use": "zbReadAttribute",
+                "params": "ep=05&clustId=0006&attrId=0000"
+            }
         }
     }
 }

--- a/core/config/devices/ptvo.switch/ptvo.switch.json
+++ b/core/config/devices/ptvo.switch/ptvo.switch.json
@@ -10,10 +10,10 @@
         },
         "type": "ptvo.switch",
         "commands": {
-            "include4": "etatEp08",
+            "Status": { "use": "zb-0006-OnOff", "params": "ep=08", "isVisible": 1 },
             "On 8": { "use": "zbCmd-0006-On", "params": "ep=08", "isVisible": 1 },
             "Off 8": { "use": "zbCmd-0006-Off", "params": "ep=08", "isVisible": 1 },
-            "Get-Etat 8": { "use": "zbReadAttribute", "params": "ep=08&clustId=0006&attrId=0000" }
+            "Get Status": { "use": "zbReadAttribute", "params": "ep=08&clustId=0006&attrId=0000" }
         }
     }
 }

--- a/core/config/devices/siren-pni-s002/siren-pni-s002.json
+++ b/core/config/devices/siren-pni-s002/siren-pni-s002.json
@@ -10,14 +10,48 @@
         },
         "type": "siren-pni-s002",
         "commands": {
-            "On 1": { "use": "zbCmd-0006-On", "params": "ep=01", "isVisible": 1 },
-            "Off 1": { "use": "zbCmd-0006-Off", "params": "ep=01", "isVisible": 1 },
-            "Get-Etat 1": { "use": "zbReadAttribute", "params": "ep=01&clustId=0006&attrId=0000" },
-            "include1 1 1 1 1": "etatEp01out",
-            "On 2": { "use": "zbCmd-0006-On", "params": "ep=02", "isVisible": 1 },
-            "Off 2": { "use": "zbCmd-0006-Off", "params": "ep=02", "isVisible": 1 },
-            "Get-Etat 2": { "use": "zbReadAttribute", "params": "ep=02&clustId=0006&attrId=0000" },
-            "include2 1 1 1 1": "etatEp02out"
+            "On 1": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=01",
+                "isVisible": 1
+            },
+            "Off 1": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=01",
+                "isVisible": 1
+            },
+            "Get-Etat 1": {
+                "use": "zbReadAttribute",
+                "params": "ep=01&clustId=0006&attrId=0000"
+            },
+            "Digital Output 1": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=1",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            },
+            "On 2": {
+                "use": "zbCmd-0006-On",
+                "params": "ep=02",
+                "isVisible": 1
+            },
+            "Off 2": {
+                "use": "zbCmd-0006-Off",
+                "params": "ep=02",
+                "isVisible": 1
+            },
+            "Get-Etat 2": {
+                "use": "zbReadAttribute",
+                "params": "ep=02&clustId=0006&attrId=0000"
+            },
+            "Digital Output 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=2",
+                "subType": "binary",
+                "genericType": "SWITCH_STATE",
+                "isVisible": 1
+            }
         }
     }
 }

--- a/core/php/AbeilleZigbeeConst.php
+++ b/core/php/AbeilleZigbeeConst.php
@@ -391,10 +391,10 @@
         "0201" => array(
             "name" => "Thermostat",
             "attributes" => array(
-                "0000" => array( "name" => "LocalTemperature", "access" => "RP", "dataType" => 0x29 ),
+                "0000" => array( "name" => "LocalTemperature", "access" => "RP", "dataType" => 0x29 ), // int16
                 "0002" => array( "name" => "Occupancy", "access" => "R", "dataType" => 0x18 ),
-                "0012" => array( "name" => "OccupiedHeatingSetpoint", "access" => "RW", "dataType" => 0x29 ),
-                "0014" => array( "name" => "UnoccupiedHeatingSetpoint", "access" => "RW", "dataType" => 0x29 ),
+                "0012" => array( "name" => "OccupiedHeatingSetpoint", "access" => "RW", "dataType" => 0x29 ), // int16
+                "0014" => array( "name" => "UnoccupiedHeatingSetpoint", "access" => "RW", "dataType" => 0x29 ), // int16
             ),
         ),
         "0202" => array(
@@ -452,6 +452,15 @@
         ),
         "0401" => array(
             "name" => "Illuminance Level Sensing",
+        ),
+        "0402" => array(
+            "name" => "Temperature Measurement",
+            "attributes" => array(
+                "0000" => array( "name" => "MeasuredValue", "access" => "R", "dataType" => 0x29 ), // int16
+                "0001" => array( "name" => "MinMeasuredValue", "access" => "R", "dataType" => 0x29 ), // int16
+                "0002" => array( "name" => "MaxMeasuredValue", "access" => "R", "dataType" => 0x29 ), // int16
+                "0003" => array( "name" => "Tolerance", "access" => "R", "dataType" => 0x29 ), // int16
+            ),
         ),
         "0405" => array(
             "name" => "Relative Humidity",
@@ -545,7 +554,7 @@
 
                 "0505" => array( "name" => "RMS Voltage", "access" => "R", "dataType" => 0x21 ),
                 "0508" => array( "name" => "RMS Current", "access" => "R", "dataType" => 0x21 ),
-                "050B" => array( "name" => "Active Power", "access" => "R", "dataType" => 0x29 ),
+                "050B" => array( "name" => "Active Power", "access" => "R", "dataType" => 0x29 ), // int16
 
                 "0602" => array( "name" => "AC Current Multiplier", "access" => "R" ),
                 "0603" => array( "name" => "AC Current Divisor", "access" => "R" ),

--- a/desktop/php/AbeilleEq-Advanced-Device.php
+++ b/desktop/php/AbeilleEq-Advanced-Device.php
@@ -26,18 +26,21 @@
     </div>
 </div>
 <div class="form-group">
-    <label class="col-sm-3 control-label">Identifiant modèle JSON</label>
+    <label class="col-sm-3 control-label">Identifiant du modèle</label>
     <div class="col-sm-5">
-        <span class="eqLogicAttr" data-l1key="configuration" data-l2key="ab::jsonId" title="Nom du fichier de config JSON utilisé"></span>
-        Source:
+        <!-- <span class="eqLogicAttr" data-l1key="configuration" data-l2key="ab::jsonId" title="Nom du fichier de config JSON utilisé"></span> -->
         <?php
+            $jsonId = $eqLogic->getConfiguration('ab::jsonId', '');
+            echo '<input readonly style="width: 200px" title="{{Nom du modèle utilisé}}" value="'.$jsonId.'" />';
+            echo '    Source:';
             $jsonLocation = $eqLogic->getConfiguration('ab::jsonLocation', 'Abeille');
             if (($jsonLocation == '') || ($jsonLocation == "Abeille"))
-                echo '<span title="Le modèle utilisé est celui fourni par Abeille">Abeille</span>';
+                $title = "Le modèle utilisé est celui fourni par Abeille";
             else
-                echo '<span title="Le modèle utilisé est un modèle local/custom">Modèle local</span>';
+                $title = "Le modèle utilisé est un modèle local/custom";
+            echo '<input readonly style="width:86px" title="{{'.$title.'}}" value="'.$jsonLocation.'" />';
 
-            $jsonId = $eqLogic->getConfiguration('ab::jsonId', '');
+            // $jsonId = $eqLogic->getConfiguration('ab::jsonId', '');
             if ($jsonId == "defaultUnknown") {
                 if ($sig) {
                     $id1 = $sig['modelId'].'_'.$sig['manufId'];

--- a/docs/fr_FR/Changelog.rst
+++ b/docs/fr_FR/Changelog.rst
@@ -1,8 +1,32 @@
 ChangeLog
 =========
 
-220402-BETA-2
--------------
+- Parser: Amélioration decode routing table.
+- WarningDevice-EL-3.0: Mise-à-jour modèle + merge 'WarningDevice'.
+- SML002: Mise-à-jour modèle (2309).
+- Affichage 'Humidity': Suppression du chiffre apres la virgule.
+- Page EQ/avancé: Amélioration (mineure) affichage modèle
+- Commande interne IAS WD ('cmd-0502') revue pour flash seul.
+- Interne: Constantes Zigbee: Ajout support cluster 0402.
+- Nettoyage cmdes JSON obsolètes:
+
+  - 'etatEpXXout' => 'zb-0006-OnOff' + 'ep=XX'
+  - 'etatEpXXin' => 'zb-0006-OnOff' + 'ep=XX'
+  - 'etatEp08' => 'zb-0006-OnOff' + 'ep=08'
+
+220406-STABLE-1
+---------------
+
+  .. important:: Pour les zigates v1, l'équipe Zigate recommande FORTEMENT d'utiliser un firmware **Optimized PDM** (OPDM) dans les cas suivants:
+
+      - Toute nouvelle installation.
+      - Dès lors qu'un réappairage complet est nécéssaire.
+      - La version OPDM corrige bon nombre de potentielles corruptions et supporte un plus grand nombre d'équipements.
+      - Les firmwares avant 3.1e sont forcement 'legacy'.
+      - Mais **ATTENTION** si vous migrez d'une version 'legacy' vers 'OPDM' il vous faudra **effacer la PDM et réapparairer tous vos équipements**.
+
+  .. important:: Les zigates v1 doivent avoir un firmware >= 3.1e pour un fonctionnement optimal.
+  .. important:: Les zigates v2 doivent être à jour du dernier firmware disponible.
 
 - Moes MS105Z: Ajout support préliminaire (2363).
 - Legrand switch 067723: Mise-à-jour modèle (2361).
@@ -144,17 +168,6 @@ ChangeLog
 
 220223-STABLE-1
 ---------------
-
-  .. important:: Pour les zigates v1, l'équipe Zigate recommande FORTEMENT d'utiliser un firmware **Optimized PDM** (OPDM) dans les cas suivants:
-
-      - Toute nouvelle installation.
-      - Dès lors qu'un réappairage complet est nécéssaire.
-      - La version OPDM corrige bon nombre de potentielles corruptions et supporte un plus grand nombre d'équipements.
-      - Les firmwares avant 3.1e sont forcement 'legacy'.
-      - Mais **ATTENTION** si vous migrez d'une version 'legacy' vers 'OPDM' il vous faudra **effacer la PDM et réapparairer tous vos équipements**.
-
-  .. important:: Les zigates v1 doivent avoir un firmware >= 3.1e pour un fonctionnement optimal.
-  .. important:: Les zigates v2 doivent être à jour du dernier firmware disponible.
 
 - Page EQ/avancé: Ajout bouton 'leave request'.
 - JSON commandes: Remplacement 'ReadAttributeRequest' => 'readAttribute'.


### PR DESCRIPTION
- Parser: Amélioration decode routing table.
- WarningDevice-EL-3.0: Mise-à-jour modèle + merge 'WarningDevice'.
- SML002: Mise-à-jour modèle (2309).
- Affichage 'Humidity': Suppression du chiffre apres la virgule.
- Page EQ/avancé: Amélioration (mineure) affichage modèle
- Commande interne IAS WD ('cmd-0502') revue pour flash seul.
- Interne: Constantes Zigbee: Ajout support cluster 0402.
- Nettoyage cmdes JSON obsolètes:

  - 'etatEpXXout' => 'zb-0006-OnOff' + 'ep=XX'
  - 'etatEpXXin' => 'zb-0006-OnOff' + 'ep=XX'
  - 'etatEp08' => 'zb-0006-OnOff' + 'ep=08'
