### PR TITLE
Tuya big rework

### DIFF
--- a/.tools/check_json.php
+++ b/.tools/check_json.php
@@ -115,7 +115,6 @@
         }
 
         $unusedCmds = &$GLOBALS['unusedCmds'];
-
         if (!isset($dev[$devName]['commands'])) {
             $error = newDevError($devName, "WARNING", "No commands defined");
         } else {
@@ -160,7 +159,7 @@
         }
 
         /* Checking supported keywords */
-        $supportedKeys = ['type', 'manufacturer', 'zbManufacturer', 'model', 'timeout', 'category', 'configuration', 'commands', 'isVisible', 'alternateIds'];
+        $supportedKeys = ['type', 'manufacturer', 'zbManufacturer', 'model', 'timeout', 'category', 'configuration', 'commands', 'isVisible', 'alternateIds', 'tuyaEF00'];
         foreach ($dev[$devName] as $key => $value) {
             if (in_array($key, $supportedKeys))
                 continue;

--- a/.tools/update_json.php
+++ b/.tools/update_json.php
@@ -516,7 +516,7 @@
                 }
             }
             $dev[$devName]['commands'] = $commands2;
-        }
+        } // End 'commands'
 
         if (isset($dev[$devName]['Comment'])) {
             $dev[$devName]['comment'] = $dev[$devName]['Comment'];
@@ -575,33 +575,50 @@
 
         if (!isset($cmd2['configuration'])) {
             newCmdError($fileName, "ERROR", "Missing 'configuration' section");
-            return;
+            // return;
+        } else {
+            /* For info cmds, logicalId added = previous configuration:topic */
+            if (($type == "info") && !isset($cmd2['logicalId'])) {
+                if (!isset($cmd2['configuration']['topic'])) {
+                    newCmdError($fileName, "ERROR", "Missing 'logicalId' field for info cmd");
+                    return;
+                }
+                $cmd2['logicalId'] = $cmd2['configuration']['topic'];
+                unset($cmd2['configuration']['topic']);
+                $cmdUpdated = true;
+                echo "  Moved 'configuration:topic' to 'logicalId'.\n";
+            }
+        if (($type == "action") && !isset($cmd2['configuration']['topic'])) {
+                newCmdError($fileName, "ERROR", "Missing 'configuration:topic' field for action cmd");
+            }
+            if (isset($cmd2['configuration']['uniqId'])) {
+                unset($cmd2['configuration']['uniqId']);
+                $cmdUpdated = true;
+                echo "  Removed 'configuration:uniqId'.\n";
+            }
+            if (isset($cmd2['configuration']['execAtCreationDelay'])) {
+                if (gettype($cmd2['configuration']['execAtCreationDelay']) == "string") {
+                    $cmd2['configuration']['execAtCreationDelay'] = (int)$cmd2['configuration']['execAtCreationDelay'];
+                    $cmdUpdated = true;
+                    echo "  'execAtCreationDelay' type changed from string to integer.\n";
+                }
+            }
         }
 
-        /* For info cmds, logicalId added = previous configuration:topic */
-        if (($type == "info") && !isset($cmd2['logicalId'])) {
-            if (!isset($cmd2['configuration']['topic'])) {
-                newCmdError($fileName, "ERROR", "Missing 'logicalId' field for info cmd");
-                return;
+        if (isset($cmd2['display'])) {
+            if (isset($cmd2['display']['forceReturnLineAfter'])) {
+                $val = $cmd2['display']['forceReturnLineAfter'];
+                if ($val == 1 || $val == "1") {
+                    $cmd2['nextLine'] = 'after';
+                    unset($cmd2['display']['forceReturnLineAfter']);
+                    $cmdUpdated = true;
+                    echo "  'forceReturnLineAfter' replaced by 'nextLine'.\n";
+                }
             }
-            $cmd2['logicalId'] = $cmd2['configuration']['topic'];
-            unset($cmd2['configuration']['topic']);
-            $cmdUpdated = true;
-            echo "  Moved 'configuration:topic' to 'logicalId'.\n";
-        }
-       if (($type == "action") && !isset($cmd2['configuration']['topic'])) {
-            newCmdError($fileName, "ERROR", "Missing 'configuration:topic' field for action cmd");
-        }
-        if (isset($cmd2['configuration']['uniqId'])) {
-            unset($cmd2['configuration']['uniqId']);
-            $cmdUpdated = true;
-            echo "  Removed 'configuration:uniqId'.\n";
-        }
-        if (isset($cmd2['configuration']['execAtCreationDelay'])) {
-            if (gettype($cmd2['configuration']['execAtCreationDelay']) == "string") {
-                $cmd2['configuration']['execAtCreationDelay'] = (int)$cmd2['configuration']['execAtCreationDelay'];
+            if (isset($cmd2['display']) && (count($cmd2['display']) == 0)) {
+                unset($cmd2['display']);
                 $cmdUpdated = true;
-                echo "  'execAtCreationDelay' type changed from string to integer.\n";
+                echo "  Empty 'display' section removed.\n";
             }
         }
 

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -34,163 +34,6 @@
 
 class Abeille extends eqLogic
 {
-    /**
-     * migrateBetweenZigates()
-     *
-     * @param beeId: bee Id to be moved
-     * @param zigateY: zigate de destination
-     *
-     * @return none
-     *
-     * https://github.com/KiwiHC16/Abeille/issues/1771
-     *
-     * 1/ Changement logical Id
-     * 2/ Remove zigbee reseau 1 zigbee
-     * 3/ inclusion normale sur le reseau 2 zigbee
-     *
-     * Faire un bouton qui fait les etapes 1/ et 2 puis demander à l'utilisateur de faire l'étape 3
-     *
-     */
-    // public static function migrateBetweenZigates($beeId, $zigateY)
-    // {
-    //     $bee = Abeille::byId($beeId);
-    //     if (!is_object($bee)) {
-    //         log::add('Abeille', 'debug', 'Erreur je ne trouve pas l abeille, je ne peux faire l operation.');
-    //         return;
-    //     }
-
-    //     $IEEE = $bee->getConfiguration('IEEE', 'none');
-    //     if ( $IEEE=='none' ) {
-    //         log::add('Abeille', 'debug', 'L Abeille na pas d adresse IEEE connue, je ne peux faire l operation.');
-    //     }
-
-    //     if ($zigateY > $GLOBALS['maxNbOfZigate']) {
-    //         log::add('Abeille', 'debug', 'Cette Zigate n existe pas: '.$zigateY.', je ne peux faire l operation.');
-    //         return;
-    //     }
-
-    //     list($destBee, $shortBee) = explode('/', $bee->getLogicalId());
-
-    //     $newDestBee = "Abeille".$zigateY;
-
-    //     // 1/ Changement logical Id
-    //     $bee->setLogicalId($newDestBee.'/'.$shortBee);
-    //     $bee->save();
-
-    //     // 2/ Remove zigbee reseau 1 zigbee
-    //     self::publishMosquitto($abQueues['xToCmd']['id'], priorityNeWokeUp, "Cmd".$newDestBee."/0000/Remove", "ParentAddressIEEE=".$IEEE."&ChildAddressIEEE=".$IEEE );
-
-    //     // 3/ inclusion normale sur le reseau 2 zigbee
-    //     message::add("Abeille", "Je viens de préparer la migration de ".$bee->getHumanName(). ". Veuillez faire maintenant son inclusion dans la zigate: ".$zigateY);
-    // }
-
-    // /**
-    //  * replaceGhost()
-    //  *
-    //  * @param ghostId: Id of the bee to be removed
-    //  * @param realId: Id of the bee which will replace the ghost and receive all informations
-    //  *
-    //  * https://github.com/KiwiHC16/Abeille/issues/1055
-    //  */
-    // public static function replaceGhost($ghostId, $realId)
-    // {
-    //     log::add('Abeille', 'debug', 'Lancement de la procedure de remplacement de '.$ghostId.' par '.$realId );
-    //     $ghost = Abeille::byId($ghostId);
-    //     if (!is_object($ghost)) {
-    //         log::add('Abeille', 'debug', 'Erreur je ne trouve pas l abeille ghost.');
-    //         return;
-    //     }
-    //     $real = Abeille::byId($realId);
-    //     if (!is_object($real)) {
-    //         log::add('Abeille', 'debug', 'Erreur je ne trouve pas l abeille réelle.');
-    //         return;
-    //     }
-
-    //     list($destGhost, $shortGhost) = explode('/', $ghost->getLogicalId());
-    //     list($destReal, $shortReal) = explode('/', $real->getLogicalId());
-
-    //     // Remove NE from ZigateX
-    //     $IEEE = $ghost->getConfiguration('IEEE', 'none');
-    //     if ( $IEEE=='none' ) {
-    //         log::add('Abeille', 'debug', 'Le ghost n a pas d adresse IEEE connue, je ne peux le retirer de la zigate.');
-    //     }
-    //     else {
-    //         log::add('Abeille', 'debug', 'Je retire '.$ghost->getName().' de la zigate.');
-    //         self::publishMosquitto($abQueues['xToCmd']['id'], priorityNeWokeUp, "Cmd".$destGhost."/0000/Remove", "ParentAddressIEEE=".$IEEE."&ChildAddressIEEE=".$IEEE );
-    //     }
-
-    //     log::add('Abeille', 'debug', 'Transfer des informations de l equipment.' );
-
-    //     log::add('Abeille', 'debug', 'Nom.' );
-    //     $real->setName($ghost->getName().'_real');
-
-    //     log::add('Abeille', 'debug', 'Parent.' );
-    //     $real->setObject($ghost->getObject());
-
-    //     // log::add('Abeille', 'debug', 'Categories.' );
-    //     // $real->setCategory($ghost->getCategory());
-
-    //     log::add('Abeille', 'debug', 'Notes.' );
-    //     $real->setConfiguration( 'note', $real->getConfiguration('note', '').$ghost->getConfiguration('note', '') );
-
-    //     log::add('Abeille', 'debug', 'positionX.' );
-    //     $real->setConfiguration( 'positionX', $ghost->getConfiguration('positionX', '') );
-
-    //     log::add('Abeille', 'debug', 'positionY.' );
-    //     $real->setConfiguration( 'positionY', $ghost->getConfiguration('positionY', '') );
-
-    //     log::add('Abeille', 'debug', 'positionZ.' );
-    //     $real->setConfiguration( 'positionZ', $ghost->getConfiguration('positionZ', '') );
-
-    //     log::add('Abeille', 'debug', 'Visibilité.' );
-    //     $real->setIsVisible($ghost->getIsVisible());
-
-    //     log::add('Abeille', 'debug', 'Enalbed/No.' );
-    //     $real->setIsEnable($ghost->getIsEnable());
-
-
-    //     if ( $ghost->getConfiguration('uniqId', '') == $real->getConfiguration('uniqId', '') ) {
-    //         log::add('Abeille', 'debug', 'Transfer du TimeOut car les equipements partagent le meme modele.' );
-    //         $real->setTimeout($ghost->getTimeout());
-    //     }
-    //     else {
-    //         log::add('Abeille', 'debug', 'Pas de transfer du TimeOut car les equipements ne partagent pas le meme modele.' );
-    //     }
-
-    //     // Parcours toutes les commandes pour recuperer les historiques, remplacer dans jeedom les instances de #ghost-cmd# par #real-cmd#
-    //     log::add('Abeille', 'debug', 'Transfer des commandes une a une.' );
-    //     foreach ($ghost->getCmd() as $numGhost => $ghostCmd) {
-    //         foreach ($real->getCmd() as $numReal => $realCmd) {
-    //             if ($ghostCmd->getLogicalId() == $realCmd->getLogicalId()) {
-    //                 if ($ghostCmd->getSubType() == $realCmd->getSubType()) {
-    //                     if ($ghostCmd->getType() == 'info' && $realCmd->getType() == 'info') {
-    //                         if ($ghostCmd->getIsHistorized() == 1) {
-    //                             // -- migrer l historique des commandes AbeilleY/YYYY vers AbeilleX/XXXX, les instances des commandes dans scenario et autres
-    //                             // history::copyHistoryToCmd('#17009#', '#17251#');
-    //                             // echo 'Copy history from '.$ghostCmd->getName().' to '.$realCmd->getName()."\n";
-    //                             log::add('Abeille', 'debug', 'Transfer de l historique pour la commande: '.$ghostCmd->getName() );
-    //                             history::copyHistoryToCmd($ghostCmd->getId(), $realCmd->getId());
-    //                         }
-    //                     }
-    //                     // -- migrer les instances des commandes dans scenario et autres
-    //                     log::add('Abeille', 'debug', 'Transfer des instance de la commande: '.$ghostCmd->getName().' dans jeedom.' );
-    //                     jeedom::replaceTag(array('#'.$ghostCmd->getId().'#' => '#'.$realCmd->getId().'#'));
-    //                 }
-    //             }
-    //         }
-    //     }
-
-    //     // -- supprimer l Abeille ghost
-    //     log::add('Abeille', 'debug', 'Suppression de l eq ghost.' );
-    //     $ghost->remove();
-
-    //     // Sauvegarde
-    //     log::add('Abeille', 'debug', 'Sauvegarde du nouvel eq.' );
-    //     $real->save();
-
-    //     return;
-    // }
-
     // Fonction dupliquée dans AbeilleParser.
     public static function volt2pourcent($voltage)
     {
@@ -208,7 +51,7 @@ class Abeille extends eqLogic
     }
 
     /**
-     * Function return data for santé page
+     * Jeedom requirement: returns health status.
      *
      * @param none
      *
@@ -219,104 +62,32 @@ class Abeille extends eqLogic
      */
     public static function health()
     {
-        $return = array();
         $result = '';
+        for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
+            if (config::byKey('AbeilleActiver'.$zgId, 'Abeille', 'N') == 'N')
+                continue; // Disabled
+            if (config::byKey('AbeilleType'.$zgId, 'Abeille', '') == 'WIFI')
+                continue; // WIFI does not use a physical port
 
-        for ($i = 1; $i <= $GLOBALS['maxNbOfZigate']; $i++) {
-            if ( config::byKey('AbeilleActiver'.$i, 'Abeille', '1', 1) ) {
-                $result .= config::byKey('AbeilleSerialPort'.$i, 'Abeille', '', 1);
-            }
+            if ($result != '')
+                $result .= ", ";
+            $result .= config::byKey('AbeilleSerialPort'.$zgId, 'Abeille', '');
         }
 
         $return[] = array(
-            'test' => 'Ports: ',             // title of the line
-            'result' => $result,             // Text which be printed in the line
-            'advice' => 'Ports utilisés',    // Text printed when mouse is on question mark icon
+            'test' => 'Ports: ',            // title of the line
+            'result' => $result,            // Text which be printed in the line
+            'advice' => 'Ports utilisés',   // Text printed when mouse is on question mark icon
             'state' => true,                // Status du plugin: true line will be green, false line will be red.
         );
 
         return $return;
     }
 
-    /**
-     * Looking for missing IEEE addresses
-     * Will fetch information from zigbee network to get all missing IEEE
-     *
-     * @return          Does not return anything as all action are triggered by sending messages in queues
-     */
-    // Tcharp38: No longer used
-    // public static function tryToGetIEEE()
+    // public static function updateConfigAbeille($abeilleIdFilter = false)
     // {
-    //     log::add('Abeille', 'debug', 'Recherche des adresses IEEE manquantes.');
-    //     $tryToGetIEEEArray = array();
-    //     $eqLogics = Abeille::byType('Abeille');
 
-    //     foreach ($eqLogics as $key => $eqLogic) {
-    //         if ($eqLogic->getIsEnable() != 1) {
-    //             log::add('Abeille', 'debug', '  Eq \''.$eqLogic->getLogicalId().'\' désactivé => ignoré');
-    //             continue; // Eq disabled => ignored
-    //         }
-    //         if ($eqLogic->getTimeout() == 1) {
-    //             log::add('Abeille', 'debug', '  Eq \''.$eqLogic->getLogicalId().'\' en timeout => ignoré');
-    //             continue; // Eq in timeout => ignored
-    //         }
-    //         if ($eqLogic->getStatus('lastCommunication') == '') {
-    //             log::add('Abeille', 'debug', '  Eq \''.$eqLogic->getLogicalId().'\' n\'a jamais communiqué => ignoré');
-    //             continue; // Eq in timeout => ignored
-    //         }
-
-    //         if (strlen($eqLogic->getConfiguration('IEEE', 'none')) == 16) {
-    //             continue; // J'ai une adresse IEEE dans la conf donc je passe mon chemin
-    //         }
-
-    //         $commandIEEE = $eqLogic->getCmd('info', 'IEEE-Addr');
-    //         if ($commandIEEE == null) {
-    //             log::add('Abeille', 'debug', '  Eq \''.$eqLogic->getLogicalId().'\' sans cmd \'IEEE-Addr\' => ignoré');
-    //             continue; // No cmd to retrieve IEEE address. Normal ?
-    //         }
-
-    //         if (strlen($commandIEEE->execCmd()) == 16) {
-    //             $eqLogic->setConfiguration('IEEE', $commandIEEE->execCmd()); // Si je suis a cette ligne c est que je n ai pas IEEE dans conf mais dans cmd alors je mets dans conf.
-    //             $eqLogic->save();
-    //             $eqLogic->refresh();
-    //             continue; // J'ai une adresse IEEE dans la commande donc je passe mon chemin
-    //         }
-
-    //         $tryToGetIEEEArray[] = $key;
-    //     }
-
-    //     // Prend x abeilles au hasard dans cette liste d'abeille a interroger.
-    //     $eqLogicIds = array_rand($tryToGetIEEEArray, 2);
-
-    //     // Pour ces x Abeilles lance l interrogation
-    //     foreach ($eqLogicIds as $eqLogicId) {
-    //         echo "Start Loop: ".$eqLogicId."\n";
-    //         // echo "Start Loop Detail: ";
-    //         $eqLogicX = $eqLogics[$tryToGetIEEEArray[$eqLogicId]];
-    //         // var_dump($eqLogic);
-    //         $commandIEEE_X = $eqLogicX->getCmd('info', 'IEEE-Addr');
-    //         if ($commandIEEE_X) {
-    //             $addrIEEE_X = $commandIEEE_X->execCmd();
-    //             if (strlen($addrIEEE_X) < 2) {
-    //                 list($dest, $NE) = explode('/', $eqLogicX->getLogicalId());
-    //                 if (strlen($NE) == 4) {
-    //                     if ($eqLogicX->getIsEnable()) {
-    //                         log::add('Abeille', 'debug', 'Demarrage tryToGetIEEE for '.$NE);
-    //                         echo 'Demarrage tryToGetIEEE for '.$NE."\n";
-    //                         $cmd = "/usr/bin/nohup php ".__DIR__."/../php/AbeilleInterrogate.php ".$dest." ".$NE." >/dev/null 2>&1 &";
-    //                         // echo "Cmd: ".$cmd."\n";
-    //                         exec($cmd, $out, $status);
-    //                     } else echo "Je n essaye pas car Abeille inactive.\n";
-    //                 } else echo "Je n ai pas recuperé l adresse courte !!!\n";
-    //             } else echo "IEEE superieure à deux carateres !!! :".$addrIEEE_X."\n";
-    //         } else echo "commandIEEE n existe pas !!!!\n";
-    //     }
     // }
-
-    public static function updateConfigAbeille($abeilleIdFilter = false)
-    {
-
-    }
 
     /**
      * executePollCmds
@@ -392,15 +163,15 @@ class Abeille extends eqLogic
      *
      * @return           eq with this IEEE or Null if not found
      */
-    public static function getEqFromIEEE($IEEE)
-    {
-        foreach (self::searchConfiguration('IEEE', 'Abeille') as $eq) {
-            if ($eq->getConfiguration('IEEE') == $IEEE) {
-                return $eq;
-            }
-        }
-        return null;
-    }
+    // public static function getEqFromIEEE($IEEE)
+    // {
+    //     foreach (self::searchConfiguration('IEEE', 'Abeille') as $eq) {
+    //         if ($eq->getConfiguration('IEEE') == $IEEE) {
+    //             return $eq;
+    //         }
+    //     }
+    //     return null;
+    // }
 
     /**
      * cronDaily
@@ -664,18 +435,18 @@ if (0) {
         // log::add( 'Abeille', 'debug', 'cron(): Start ------------------------------------------------------------------------------------------------------------------------' );
         $config = AbeilleTools::getParameters();
 
-        $running = AbeilleTools::getRunningDaemons();
-        $status = AbeilleTools::checkAllDaemons($config, $running);
+        // Check & restart missing daemons
+        $dStatus = AbeilleTools::checkAllDaemons2($config);
 
         /* For debug purposes, display 'PID/daemonShortName' */
-        $status = AbeilleTools::getRunningDaemons2();
-        $daemons = "";
-        foreach ($status['daemons'] as $daemon) {
-            if ($daemons != "")
-                $daemons .= ", ";
-            $daemons .= $daemon['pid'].'/'.$daemon['shortName'];
+        // $running = AbeilleTools::getRunningDaemons2();
+        $dTxt = "";
+        foreach ($dStatus['running']['daemons'] as $daemonName => $daemon) {
+            if ($dTxt != "")
+                $dTxt .= ", ";
+            $dTxt .= $daemon['pid'].'/'.$daemonName;
         }
-        log::add('Abeille', 'debug', 'cron(): Daemons: '.$daemons);
+        log::add('Abeille', 'debug', 'cron(): Daemons: '.$dTxt);
 
         // Checking queues status to log any potential issue.
         // Moved from deamon_info()
@@ -860,7 +631,7 @@ if (0) {
 
         /* Check & update configuration DB if required. */
         $dbVersion = config::byKey('DbVersion', 'Abeille', '');
-        $dbVersionLast = 20201122;
+        $dbVersionLast = 20220407;
         if (($dbVersion == '') || (intval($dbVersion) < $dbVersionLast)) {
             log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v'.$dbVersion.' < v'.$dbVersionLast.' => Update required.');
             updateConfigDB();
@@ -964,7 +735,7 @@ if (0) {
         $timeout = 10;
         for ($t = 0; $t < $timeout; $t++) {
             $runArr = AbeilleTools::getRunningDaemons2();
-            if (($runArr['running'] & $expected) == $expected)
+            if (($runArr['runBits'] & $expected) == $expected)
                 break;
             sleep(1);
         }
@@ -1015,12 +786,12 @@ if (0) {
         // Tcharp38 note: when all queues in $abQueues, we can delete $allQueues
         $abQueues = $GLOBALS['abQueues'];
         $allQueues = array(
-            $abQueues["abeilleToAbeille"]["id"], /* queueKeyAbeilleToCmd, */ $abQueues["parserToAbeille"]["id"], $abQueues["parserToAbeille2"]["id"], $abQueues["cmdToAbeille"]["id"],
+            $abQueues["abeilleToAbeille"]["id"], $abQueues["parserToAbeille"]["id"], $abQueues["parserToAbeille2"]["id"], $abQueues["cmdToAbeille"]["id"],
             $abQueues["cmdToMon"]["id"], $abQueues["parserToMon"]["id"], $abQueues["monToCmd"]["id"],
-            $abQueues["assistToParser"]["id"], $abQueues["parserToAssist"]["id"], $abQueues["assistToCmd"]["id"],
-            $abQueues["parserToLQI"]["id"], /* $abQueues["LQIToCmd"]["id"], */
-            $abQueues["xmlToAbeille"]["id"], /* queueKeyXmlToCmd, queueKeyFormToCmd, */ $abQueues["parserToCli"]["id"],
-            /* $abQueues["parserToCmd"]["id"], */ /* queueKeyCmdToCmd, */ $abQueues["serialToParser"]["id"], $abQueues["parserToCmdAck"]["id"], $abQueues["ctrlToParser"]["id"]
+            $abQueues["parserToAssist"]["id"], $abQueues["assistToCmd"]["id"],
+            $abQueues["parserToLQI"]["id"],
+            $abQueues["xmlToAbeille"]["id"], $abQueues["parserToCli"]["id"],
+            $abQueues["xToParser"]["id"], $abQueues["parserToCmdAck"]["id"]
         );
         foreach ($allQueues as $queueId) {
             $queue = msg_get_queue($queueId);
@@ -1482,76 +1253,13 @@ if (0) {
 
         // Le capteur de temperature rond V1 xiaomi envoie spontanement son nom: ->lumi.sensor_ht<- mais envoie ->lumi.sens<- sur un getName
         // Tcharp38: To be removed. This cleanup is now done directly in parser on modelIdentifier receive
-        if ($cmdId == "0000-01-0005") {
-            if ($value == "lumi.sens") {
-                $value = "lumi.sensor_ht";
-                message::add("Abeille", "lumi.sensor_ht case tracking: ".json_encode($message), '');
-            }
-            if ($value == "lumi.sensor_swit") $value = "lumi.sensor_switch.aq3";
-            if ($value == "TRADFRI Signal Repeater") $value = "TRADFRI signal repeater";
-        }
-
-        // Tcharp38: No longer required here. Treated by msgFromParser()
-        //           'enable is part of 'eqAnnounce' while 'disable' is part of 'leaveIndication' msg.
-        // /* Treat "enable" (device announce) or "disable" (leave indication) cmds. */
-        // if (($cmdId == "enable") || ($cmdId == "disable")) {
-        //     log::add('Abeille', 'debug', 'message(): '.$cmdId.': net='.$Filter.', IEEE='.$value);
-
-        //     /* Look for corresponding equipment (identified via its IEEE addr) */
-        //     $allBees = self::byType('Abeille');
-        //     $missingIEEE = array(); // List of eq with missing IEEE
-        //     foreach ($allBees as $key=>$bee) {
-        //         $beeLogicId = $bee->getLogicalId(); // Ex: 'Abeille1/xxxx'
-        //         list($net, $oldAddr) = explode( "/", $beeLogicId);
-        //         if ($net != $Filter) // TODO: $Filter = 'AbeilleX' ??
-        //             continue; // Not on expected network
-
-        //         $ieee = $bee->getConfiguration('IEEE', 'none');
-        //         if ($ieee == 'none') {
-        //             $missingIEEE[] = $bee;
-        //             continue; // No registered IEEE
-        //         }
-        //         if ($ieee != $value)
-        //             continue; // Not the right equipment
-
-        //         $matchingBee = $bee;
-        //         break; // No need to go thru other equipments
+        // if ($cmdId == "0000-01-0005") {
+        //     if ($value == "lumi.sens") {
+        //         $value = "lumi.sensor_ht";
+        //         message::add("Abeille", "lumi.sensor_ht case tracking: ".json_encode($message), '');
         //     }
-
-        //     /* If eq not found, might be due to missing IEEE. Let's check */
-        //     if (!isset($matchingBee) && (sizeof($missingIEEE) != 0)) {
-        //         log::add('Abeille', 'debug', 'message(): '.$cmdId.': Vérification des adresses IEEE manquantes');
-        //         foreach ($missingIEEE as $bee) {
-        //             $cmd = $bee->getCmd('info', 'IEEE-Addr');
-        //             if ($cmd->execCmd() != $value)
-        //                 continue; // Still not the correct eq
-
-        //             $matchingBee = $bee;
-        //             break; // No need to go thru other equipments
-        //         }
-        //     }
-
-        //     if (isset($matchingBee)) {
-        //         if ($cmdId == "enable") {
-        //             $bee->setIsEnable(1);
-        //             /* Updating logical ID since short address changed with device announce */
-        //             $oldLogicId = $bee->getLogicalId();
-        //             $nodeid = $Filter.'/'.$addr;
-        //             $bee->setLogicalId($nodeid);
-        //             log::add('Abeille', 'debug', 'message(): disable: Mise-à-jour '.$oldLogicId.' => '.$nodeid);
-        //             // message::add("Abeille", "'".$bee->getHumanName()."' a rejoint le réseau.", '');
-        //         } else {
-        //             $bee->setIsEnable(0);
-        //             /* Display message only if NOT in include mode */
-        //             if (self::checkInclusionStatus($dest) != 1)
-        //                 message::add("Abeille", "'".$bee->getHumanName()."' a quitté le réseau => désactivé.", '');
-        //         }
-        //         $bee->save();
-        //         $bee->refresh();
-        //     } else
-        //         log::add('Abeille', 'debug', 'message(): '.$cmdId.': Eq '.$Filter.'-'.$value.' pas trouvé dans Jeedom.');
-
-        //     return;
+        //     if ($value == "lumi.sensor_swit") $value = "lumi.sensor_switch.aq3";
+        //     if ($value == "TRADFRI Signal Repeater") $value = "TRADFRI signal repeater";
         // }
 
         /* Request to create virtual remote control */
@@ -1647,132 +1355,105 @@ if (0) {
         /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
         /* If unknown eq and IEEE received, looking for eq with same IEEE to update logicalName & topic */
         // e.g. Short address change (Si l adresse a changé, on ne peut pas trouver l objet par son nodeId)
-        if (!is_object($eqLogic) && ($cmdId == "IEEE-Addr")) {
-            log::add('Abeille', 'debug', 'message(), !objet & IEEE: Recherche de l\'equipement correspondant');
-            // 0 : Short Address is aligned with the one received
-            // Short : Short Address is NOT aligned with the one received
-            // -1 : Error Nothing found
-            $ShortFound = Abeille::fetchShortFromIEEE($value, $addr);
-            log::add('Abeille', 'debug', 'message(), !objet & IEEE: Trouvé='.$ShortFound);
-            if ((strlen($ShortFound) == 4) && ($addr != "0000")) {
+        // if (!is_object($eqLogic) && ($cmdId == "IEEE-Addr")) {
+        //     log::add('Abeille', 'debug', 'message(), !objet & IEEE: Recherche de l\'equipement correspondant');
+        //     // 0 : Short Address is aligned with the one received
+        //     // Short : Short Address is NOT aligned with the one received
+        //     // -1 : Error Nothing found
+        //     $ShortFound = Abeille::fetchShortFromIEEE($value, $addr);
+        //     log::add('Abeille', 'debug', 'message(), !objet & IEEE: Trouvé='.$ShortFound);
+        //     if ((strlen($ShortFound) == 4) && ($addr != "0000")) {
 
-                $eqLogic = self::byLogicalId($dest."/".$ShortFound, 'Abeille');
-                if (!is_object($eqLogic)) {
-                    log::add('Abeille', 'debug', 'message(), !objet & IEEE: L\'équipement ne semble pas sur la bonne zigate. Abeille ne fait rien automatiquement. L\'utilisateur doit résoudre la situation.');
-                    return;
-                }
+        //         $eqLogic = self::byLogicalId($dest."/".$ShortFound, 'Abeille');
+        //         if (!is_object($eqLogic)) {
+        //             log::add('Abeille', 'debug', 'message(), !objet & IEEE: L\'équipement ne semble pas sur la bonne zigate. Abeille ne fait rien automatiquement. L\'utilisateur doit résoudre la situation.');
+        //             return;
+        //         }
 
-                // log::add('Abeille', 'debug', "message(), !objet & IEEE: Adresse IEEE $value pour $addr qui remonte est deja dans l objet $ShortFound - ".$eqLogic->getName().", on fait la mise a jour automatique");
-                log::add('Abeille', 'debug', "message(), !objet & IEEE: $value correspond à '".$eqLogic->getHumanName()."'. Mise-à-jour de l'adresse courte $ShortFound vers $addr.");
-                // Comme c est automatique des que le retour d experience sera suffisant, on n alerte pas l utilisateur. Il n a pas besoin de savoir
-                // message::add("Abeille", "IEEE-Addr; adresse IEEE $value pour $addr qui remonte est deja dans l objet $ShortFound - ".$eqLogic->getName().", on fait la mise a jour automatique", '');
-                message::add("Abeille", "Nouvelle adresse '".$addr."' pour '".$eqLogic->getHumanName()."'. Mise à jour automatique.");
+        //         // log::add('Abeille', 'debug', "message(), !objet & IEEE: Adresse IEEE $value pour $addr qui remonte est deja dans l objet $ShortFound - ".$eqLogic->getName().", on fait la mise a jour automatique");
+        //         log::add('Abeille', 'debug', "message(), !objet & IEEE: $value correspond à '".$eqLogic->getHumanName()."'. Mise-à-jour de l'adresse courte $ShortFound vers $addr.");
+        //         // Comme c est automatique des que le retour d experience sera suffisant, on n alerte pas l utilisateur. Il n a pas besoin de savoir
+        //         // message::add("Abeille", "IEEE-Addr; adresse IEEE $value pour $addr qui remonte est deja dans l objet $ShortFound - ".$eqLogic->getName().", on fait la mise a jour automatique", '');
+        //         message::add("Abeille", "Nouvelle adresse '".$addr."' pour '".$eqLogic->getHumanName()."'. Mise à jour automatique.");
 
-                // Si on trouve l adresse dans le nom, on remplace par la nouvelle adresse
-                // log::add('Abeille', 'debug', "!objet&IEEE --> IEEE-Addr; Ancien nom: ".$eqLogic->getName().", nouveau nom: ".str_replace($ShortFound, $addr, $eqLogic->getName()));
-                // $eqLogic->setName(str_replace($ShortFound, $addr, $eqLogic->getName()));
+        //         // Si on trouve l adresse dans le nom, on remplace par la nouvelle adresse
+        //         // log::add('Abeille', 'debug', "!objet&IEEE --> IEEE-Addr; Ancien nom: ".$eqLogic->getName().", nouveau nom: ".str_replace($ShortFound, $addr, $eqLogic->getName()));
+        //         // $eqLogic->setName(str_replace($ShortFound, $addr, $eqLogic->getName()));
 
-                $eqLogic->setLogicalId($dest."/".$addr);
-                $eqLogic->setConfiguration('topic', $dest."/".$addr);
-                $eqLogic->save();
+        //         $eqLogic->setLogicalId($dest."/".$addr);
+        //         $eqLogic->setConfiguration('topic', $dest."/".$addr);
+        //         $eqLogic->save();
 
-                // Il faut aussi mettre a jour la commande short address
-                Abeille::publishMosquitto($abQueues["abeilleToAbeille"]["id"], priorityInterrogation, $dest."/".$addr."/Short-Addr", $addr);
-            } else {
-                log::add('Abeille', 'debug', 'message(), !objet & IEEE: Je n ai pas trouvé d Abeille qui corresponde.');
-                // self::interrogateUnknowNE( $dest, $addr );
-            }
-            // log::add('Abeille', 'debug', '!objet&IEEE --> fin du traitement');
-            return;
-        }
+        //         // Il faut aussi mettre a jour la commande short address
+        //         Abeille::publishMosquitto($abQueues["abeilleToAbeille"]["id"], priorityInterrogation, $dest."/".$addr."/Short-Addr", $addr);
+        //     } else {
+        //         log::add('Abeille', 'debug', 'message(), !objet & IEEE: Je n ai pas trouvé d Abeille qui corresponde.');
+        //         // self::interrogateUnknowNE( $dest, $addr );
+        //     }
+        //     // log::add('Abeille', 'debug', '!objet&IEEE --> fin du traitement');
+        //     return;
+        // }
 
         /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
         // Si l objet n existe pas et je recoie une commande => je drop la cmd but I try to get the device into Abeille
         // e.g. un Equipement envoie des infos, mais l objet n existe pas dans Jeedom
-        if (!is_object($eqLogic)) {
+        // if (!is_object($eqLogic)) {
 
-            // Je ne fais les demandes que si les commandes ne sont pas Time-Time, Time-Stamp et Link-Quality
-            if (!preg_match("(Time|Link-Quality)", $topic)) {
+        //     // Je ne fais les demandes que si les commandes ne sont pas Time-Time, Time-Stamp et Link-Quality
+        //     if (!preg_match("(Time|Link-Quality)", $topic)) {
 
-                if (!Abeille::checkInclusionStatus($dest)) {
-                    log::add('Abeille', 'info', 'Des informations remontent pour un equipement inconnu d Abeille avec pour adresse '.$addr.' et pour la commande '.$cmdId );
-                }
+        //         if (!Abeille::checkInclusionStatus($dest)) {
+        //             log::add('Abeille', 'info', 'Des informations remontent pour un equipement inconnu d Abeille avec pour adresse '.$addr.' et pour la commande '.$cmdId );
+        //         }
 
-                // self::interrogateUnknowNE( $dest, $addr );
-            }
+        //         // self::interrogateUnknowNE( $dest, $addr );
+        //     }
 
-            return;
-        }
+        //     return;
+        // }
 
         /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
         // Si l objet exist et on recoie une IEEE
         // e.g. Un NE renvoie son annonce
-        if (is_object($eqLogic) && ($cmdId == "IEEE-Addr")) {
+        // if (is_object($eqLogic) && ($cmdId == "IEEE-Addr")) {
 
-            // Je rejete les valeur null (arrive avec les equipement xiaomi qui envoie leur nom spontanement alors que l IEEE n est pas recue.
-            if (strlen($value) < 2) {
-                log::add('Abeille', 'debug', 'IEEE-Addr; =>'.$value.'<= ; IEEE non valable pour un equipement, valeur rejetée: '.$addr.": IEEE =>".$value."<=");
-                return;
-            }
+        //     // Je rejete les valeur null (arrive avec les equipement xiaomi qui envoie leur nom spontanement alors que l IEEE n est pas recue.
+        //     if (strlen($value) < 2) {
+        //         log::add('Abeille', 'debug', 'IEEE-Addr; =>'.$value.'<= ; IEEE non valable pour un equipement, valeur rejetée: '.$addr.": IEEE =>".$value."<=");
+        //         return;
+        //     }
 
-            // Je ne sais pas pourquoi des fois on recoit des IEEE null
-            if ($value == "0000000000000000") {
-                log::add('Abeille', 'debug', 'IEEE-Addr;'.$value.';IEEE recue est null, je ne fais rien.');
-                return;
-            }
+        //     // Je ne sais pas pourquoi des fois on recoit des IEEE null
+        //     if ($value == "0000000000000000") {
+        //         log::add('Abeille', 'debug', 'IEEE-Addr;'.$value.';IEEE recue est null, je ne fais rien.');
+        //         return;
+        //     }
 
-            // ffffffffffffffff remonte avec les mesures LQI si nouveau equipements.
-            if ($value == "FFFFFFFFFFFFFFFF") {
-                log::add('Abeille', 'debug', 'IEEE-Addr; =>'.$value.'<= ; IEEE non valable pour un equipement, valeur rejetée: '.$addr.": IEEE =>".$value."<=");
-                return;
-            }
+        //     // ffffffffffffffff remonte avec les mesures LQI si nouveau equipements.
+        //     if ($value == "FFFFFFFFFFFFFFFF") {
+        //         log::add('Abeille', 'debug', 'IEEE-Addr; =>'.$value.'<= ; IEEE non valable pour un equipement, valeur rejetée: '.$addr.": IEEE =>".$value."<=");
+        //         return;
+        //     }
 
-            // Update IEEE cmd
-            if (!is_object($cmdLogic)) {
-                log::add('Abeille', 'debug', 'IEEE-Addr commande n existe pas');
-                return;
-            }
+        //     // Update IEEE cmd
+        //     if (!is_object($cmdLogic)) {
+        //         log::add('Abeille', 'debug', 'IEEE-Addr commande n existe pas');
+        //         return;
+        //     }
 
-            // $IEEE = $cmdLogic->execCmd();
-            $IEEE = $eqLogic->getConfiguration('IEEE','None');
-            if ( ($IEEE!=$value) && (strlen($IEEE)==16) ) {
-                log::add('Abeille', 'debug', 'IEEE-Addr;'.$value.';Alerte changement de l adresse IEEE pour un equipement !!! '.$addr.": ".$IEEE." =>".$value."<=");
-                message::add("Abeille", "Alerte changement de l adresse IEEE pour un equipement !!! ( $addr : $IEEE =>$value<= )", '');
-            }
+        //     // $IEEE = $cmdLogic->execCmd();
+        //     $IEEE = $eqLogic->getConfiguration('IEEE','None');
+        //     if ( ($IEEE!=$value) && (strlen($IEEE)==16) ) {
+        //         log::add('Abeille', 'debug', 'IEEE-Addr;'.$value.';Alerte changement de l adresse IEEE pour un equipement !!! '.$addr.": ".$IEEE." =>".$value."<=");
+        //         message::add("Abeille", "Alerte changement de l adresse IEEE pour un equipement !!! ( $addr : $IEEE =>$value<= )", '');
+        //     }
 
-            $eqLogic->checkAndUpdateCmd($cmdLogic, $value);
-            $eqLogic->setConfiguration('IEEE', $value);
-            $eqLogic->save();
-            $eqLogic->refresh();
-
-            log::add('Abeille', 'debug', '  IEEE-Addr cmd and eq updated: '.$eqLogic->getName().' - '.$eqLogic->getConfiguration('IEEE', 'Unknown') );
-
-            return;
-        }
-
-        /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
-        // Tcharp38: No longer required. MACCap is collected during device announce and passed thru "eqAnnounce" msg (treated by msgFromParser())
-        // // Si l objet exist et on recoie une MACCapa
-        // // e.g. Un NE renvoie son annonce
-        // if (is_object($eqLogic) && ($cmdId == "MACCapa-MACCapa")) {
-
-        //     log::add('Abeille', 'debug', 'MACCapa-MACCapa: '.$value.' saving into eqlogic');
-
-        //     $mc = hexdec($value);
-        //     $rxOnWhenIdle = ($mc >> 3) & 0b1;
-        //     $powerSource = ($mc >> 2) & 0b1;
-
-        //     $eqLogic->setConfiguration('MACCapa', $value);
-        //     if ($powerSource) // 1=mains-powererd
-        //         $eqLogic->setConfiguration('AC_Power', 1);
-        //     else
-        //         $eqLogic->setConfiguration('AC_Power', 0);
-        //     if ($rxOnWhenIdle) // 1=Receiver enabled when idle
-        //         $eqLogic->setConfiguration('RxOnWhenIdle', 1);
-        //     else
-        //         $eqLogic->setConfiguration('RxOnWhenIdle', 0);
+        //     $eqLogic->checkAndUpdateCmd($cmdLogic, $value);
+        //     $eqLogic->setConfiguration('IEEE', $value);
         //     $eqLogic->save();
         //     $eqLogic->refresh();
+
+        //     log::add('Abeille', 'debug', '  IEEE-Addr cmd and eq updated: '.$eqLogic->getName().' - '.$eqLogic->getConfiguration('IEEE', 'Unknown') );
 
         //     return;
         // }
@@ -1819,7 +1500,7 @@ if (0) {
 
             $eqLogic->checkAndUpdateCmd($cmdLogic, $value);
 
-            Abeille::infoCmdUpdate($eqLogic, $cmdLogic, $value);
+            // Abeille::infoCmdUpdate($eqLogic, $cmdLogic, $value);
 
             // // Polling to trigger based on this info cmd change: e.g. state moved to On, getPower value.
             // $cmds = AbeilleCmd::searchConfigurationEqLogic($eqLogic->getId(), 'PollingOnCmdChange', 'action');
@@ -1835,12 +1516,12 @@ if (0) {
             return;
         }
 
-        if (is_object($eqLogic) && !is_object($cmdLogic)) {
-            log::add('Abeille', 'debug', "  L'objet '".$nodeid."' existe mais pas la cmde '".$cmdId."' => message ignoré");
-            return;
-        }
+        // if (is_object($eqLogic) && !is_object($cmdLogic)) {
+        //     log::add('Abeille', 'debug', "  L'objet '".$nodeid."' existe mais pas la cmde '".$cmdId."' => message ignoré");
+        //     return;
+        // }
 
-        log::add('Abeille', 'debug', "  WARNING: Unexpected state at end of message().");
+        log::add('Abeille', 'debug', "  WARNING: Unexpected or no longer supported message.");
         return;
     } // End message()
 
@@ -2698,7 +2379,7 @@ if (0) {
         $eqLogic->save();
     } // End newJeedomDevice()
 
-    /* Create or update Jeedom device based on its JSON config.
+    /* Create or update Jeedom device based on its JSON model.
        Called in the following cases
        - On 'eqAnnounce' message from parser (device announce) => action = 'create'
        - To create a virtual 'remotecontrol' => action = 'create'
@@ -2894,9 +2575,22 @@ if (0) {
         else
             $eqLogic->setConfiguration('poll', null);
 
-        $eqLogic->setIsEnable(1);
+        // Tuya specific infos
+        if (isset($modelEq['tuyaEF00']))
+            $eqLogic->setConfiguration('ab::tuyaEF00', $modelEq['tuyaEF00']);
+        else
+            $eqLogic->setConfiguration('ab::tuyaEF00', null);
+
+        // JSON model infos
+        $eqModelInfos = array(
+            'id' => $jsonId, // Note: To replace 'ab::jsonId'
+            'location' => $jsonLocation, // Note: To replace 'ab::jsonLocation'
+            'type' => $modelEq['type'],
+        );
+        $eqLogic->setConfiguration('ab::eqModel', $eqModelInfos);
 
         // $eqLogic->setStatus('lastCommunication', date('Y-m-d H:i:s')); // Tcharp38: Done by updateTimestamp()
+        $eqLogic->setIsEnable(1);
         $eqLogic->save();
 
         /* During commands creation #EP# must be replaced by proper endpoint.
@@ -2975,29 +2669,31 @@ if (0) {
                was used somewhere in Jeedom.
              */
             $cmdLogic = null;
-            if ($mCmdType == 'info') {
-                // $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $mCmdLogicalId);
-                foreach ($jeedomCmds as $jCmdId => $jCmd) {
-                    if ($jCmd['type'] != 'info')
-                        continue;
-                    if ($jCmd['logicalId'] != $mCmdLogicalId)
-                        continue;
-                    // TODO if ($jCmd['updated'] == 1)
-                    //     continue; // ERROR: Possible ?
-                    $cmdLogic = $jCmd['cmdLogic'];
-                    break;
-                }
-            } else {
-                // $cmdLogic = AbeilleCmd::byEqLogicIdCmdName($eqLogic->getId(), $mCmdName);
-                foreach ($jeedomCmds as $jCmdId => $jCmd) {
-                    if ($jCmd['type'] != 'action')
-                        continue;
-                    // if ($jCmd['logicalId'] != $mCmdLogicalId)
-                    //     continue;
-                    if ($jCmd['name'] != $mCmdName)
-                        continue;
-                    $cmdLogic = $jCmd['cmdLogic'];
-                    break;
+            if ($jeedomCmds) {
+                if ($mCmdType == 'info') {
+                    // $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $mCmdLogicalId);
+                    foreach ($jeedomCmds as $jCmdId => $jCmd) {
+                        if ($jCmd['type'] != 'info')
+                            continue;
+                        if ($jCmd['logicalId'] != $mCmdLogicalId)
+                            continue;
+                        // TODO if ($jCmd['updated'] == 1)
+                        //     continue; // ERROR: Possible ?
+                        $cmdLogic = $jCmd['cmdLogic'];
+                        break;
+                    }
+                } else {
+                    // $cmdLogic = AbeilleCmd::byEqLogicIdCmdName($eqLogic->getId(), $mCmdName);
+                    foreach ($jeedomCmds as $jCmdId => $jCmd) {
+                        if ($jCmd['type'] != 'action')
+                            continue;
+                        // if ($jCmd['logicalId'] != $mCmdLogicalId)
+                        //     continue;
+                        if ($jCmd['name'] != $mCmdName)
+                            continue;
+                        $cmdLogic = $jCmd['cmdLogic'];
+                        break;
+                    }
                 }
             }
             if (!is_object($cmdLogic)) {
@@ -3120,20 +2816,25 @@ if (0) {
 
             // On conserve l info du template pour la visibility
             // Tcharp38: What for ? Not found where it is used
-            if (isset($mCmd["isVisible"]))
-                $cmdLogic->setConfiguration("visibiltyTemplate", $mCmd["isVisible"]);
+            // if (isset($mCmd["isVisible"]))
+            //     $cmdLogic->setConfiguration("visibiltyTemplate", $mCmd["isVisible"]);
 
             // Display stuff is updated only if new eq or new cmd to not overwrite user changes
             if (($action == 'reset') || $newCmd) {
-                // TODO: Update all JSON to move "invertBinary" into "display" section
-                if (isset($mCmd["invertBinary"])) {
+                if (isset($mCmd["invertBinary"]))
                     $cmdLogic->setDisplay('invertBinary', $mCmd["invertBinary"]);
+                else
+                    $cmdLogic->setDisplay('invertBinary', null);
+
+                if (isset($mCmd["nextLine"])) {
+                    if ($mCmd["nextLine"] == "after")
+                        $cmdLogic->setDisplay('forceReturnLineAfter', 1);
+                    else
+                        $cmdLogic->setDisplay('forceReturnLineBefore', 1);
+                } else {
+                    $cmdLogic->setDisplay('forceReturnLineAfter', null);
+                    $cmdLogic->setDisplay('forceReturnLineBefore', null);
                 }
-                if (array_key_exists("display", $mCmd))
-                    foreach ($mCmd["display"] as $confKey => $confValue) {
-                        $cmdLogic->setDisplay($confKey, $confValue);
-                    }
-                // TODO: Missing a way to remove obsolete entries
             }
 
             $cmdLogic->save();

--- a/core/config/Abeille.config.php
+++ b/core/config/Abeille.config.php
@@ -11,8 +11,7 @@
     /* Inter-daemons queues:
        array['<queueName>'] = array("id" => queueId, "max" => maxMsgSize) */
     $abQueues = array();
-    $abQueues["serialToParser"] = array( "id" => 0x336, "max" => 2048 );
-    $abQueues["ctrlToParser"] = array( "id" => 0x337, "max" => 2048 ); // Ctrl messages for AbeilleParser
+    $abQueues["xToParser"] = array( "id" => 0x336, "max" => 2048 );
     $abQueues["ctrlToCmd"] = array( "id" => 0x338, "max" => 2048 ); // Ctrl messages for AbeilleCmd
     $abQueues["parserToLQI"] = array( "id" => 0xE1, "max" => 2048 );
     $abQueues["parserToCli"] = array( "id" => 0x2D4, "max" => 1024 );
@@ -24,7 +23,6 @@
     $abQueues["cmdToMon"] = array( "id" => 130, "max" => 512 ); // Messages to zigate (cmd to monitor)
     $abQueues["parserToMon"] = array( "id" => 131, "max" => 512 ); // Messages from zigate (parser to monitor)
     $abQueues["monToCmd"] = array( "id" => 132, "max" => 512 ); // Messages to cmd (addr update)
-    $abQueues["assistToParser"] = array( "id" => 140, "max" => 512 ); // Assistant to parser
     $abQueues["parserToAssist"] = array( "id" => 141, "max" => 512 ); // Parser to EQ assistant
     $abQueues["assistToCmd"] = array( "id" => 142, "max" => 512 ); // Assistant to cmd
     $abQueues["abeilleToAbeille"] = array( "id" => 121, "max" => 512 ); // ?

--- a/core/config/commands/Click-Middle.json
+++ b/core/config/commands/Click-Middle.json
@@ -10,10 +10,8 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
-        "logicalId": "Click-Middle"
+        "logicalId": "Click-Middle",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/ColourRGB.json
+++ b/core/config/commands/ColourRGB.json
@@ -5,15 +5,13 @@
         "isHistorized": "0",
         "subType": "string",
         "template": "badge",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "visibilityCategory": "additionalCommand"
         },
         "type": "info",
         "logicalId": "ColourRGB",
         "unit": "",
-        "genericType": "LIGHT_COLOR"
+        "genericType": "LIGHT_COLOR",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/LISEZMOI.txt
+++ b/core/config/commands/LISEZMOI.txt
@@ -11,11 +11,16 @@ Attention !! Toute modification de ce répertoire sera écrasée lors des mises-
 Nom des commandes
 =================
 En dehors des commandes "historiques" en passe d'être normalisées, les noms de fichiers doivent suivre les regles suivantes:
-- Toute commande specifique Zigbee (issu de la spec) commence par "zb"
+- Toute commande specifique Zigbee (issu du standard Zigbee) commence par "zb"
 - Le nom des commandes commence par une minuscule (ex: click.json)
-- zbCmd-<cluster>-<cmdName>.json : une commande du 'cluster' (ex: zbCmd-0006-On). Donc forcement commande Jeedom ACTION.
+- zbCmd-<cluster>-<cmdName>.json : une commande du 'cluster', générée par la Zigate (ex: zbCmd-0006-On).
+  Peut donc être déclenchée d'une commande Jeedom du type ACTION.
+  TODO: A renommer en 'zbCmdG-<clustId>-<cmdName>'
+- zbCmdR-<cluster>-<cmdName>.json
+  Une commande "reçue" par la Zigate. Peut donc alimenter une commande Jeedom du type INFO.
 - zb-<cluster>-<attribName>.json: un attribut du 'cluster' (ex: zb-0001-BatteryPercent) = Command Jeedom du type INFO.
   Ces commandes Jeedom sont mises à jour par un "attribute report" ou "read attribute response".
+  TODO: A renommer en 'zbAttr-<clustId>-<attrName>'
 - zbConfigureReporting, zbReadAttribute... actions du standard Zigbee.
 
 Format de fichier
@@ -94,6 +99,9 @@ Exemple de commande 'action'
   Permet de définir le widget qui sera utilisé pour l'affichage de la commande.
 
 * value: ??
+
+* nextLine: after/before
+  Impacte l'affichage du widget. Permet de forcer un saut de ligne apres ou avant le widget de la commande.
 
 * configuration:
 

--- a/core/config/commands/Left-Right-Cmd.json
+++ b/core/config/commands/Left-Right-Cmd.json
@@ -10,10 +10,8 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
-        "logicalId": "80A7-Cmd"
+        "logicalId": "80A7-Cmd",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/Left-Right-Direction.json
+++ b/core/config/commands/Left-Right-Direction.json
@@ -10,10 +10,8 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
-        "logicalId": "80A7-Direction"
+        "logicalId": "80A7-Direction",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/Up-Down.json
+++ b/core/config/commands/Up-Down.json
@@ -10,10 +10,8 @@
             "visibilityCategory": "All",
             "repeatEventManagement": "always"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
-        "logicalId": "Up-Down"
+        "logicalId": "Up-Down",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/VertGroup.json
+++ b/core/config/commands/VertGroup.json
@@ -9,9 +9,7 @@
             "request": "X=147A&Y=D709",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP1.json
+++ b/core/config/commands/addGroupEP1.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 1
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP3.json
+++ b/core/config/commands/addGroupEP3.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 3
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP4.json
+++ b/core/config/commands/addGroupEP4.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 5
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP5.json
+++ b/core/config/commands/addGroupEP5.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 7
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP6.json
+++ b/core/config/commands/addGroupEP6.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 9
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP7.json
+++ b/core/config/commands/addGroupEP7.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 11
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/addGroupEP8.json
+++ b/core/config/commands/addGroupEP8.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 13
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/attr-Door-Status.json
+++ b/core/config/commands/attr-Door-Status.json
@@ -1,0 +1,14 @@
+{
+    "attr-Door-Status": {
+        "comment": "A generic attribut to display a door/window status",
+        "comment2": "Ex: Received window detection status from thermostat",
+        "comment3": "Tcharp38: Can we map on a Zigbee standard attribute ?",
+        "subType": "binary",
+        "template": "door",
+        "type": "info",
+        "logicalId": "#EP#-doorStatus",
+        "unit": "",
+        "invertBinary": 1,
+        "genericType": "OPENING"
+    }
+}

--- a/core/config/commands/attr-Generic.json
+++ b/core/config/commands/attr-Generic.json
@@ -1,0 +1,12 @@
+{
+    "attr-Generic": {
+        "comment": "Generic attribute",
+        "comment2": "To be overloaded from device model",
+        "type": "info",
+        "subType": "other",
+        "template": "badge",
+        "logicalId": "toBeFilledByDevice",
+        "unit": "",
+        "genericType": ""
+    }
+}

--- a/core/config/commands/attr-Thermostat-Mode.json
+++ b/core/config/commands/attr-Thermostat-Mode.json
@@ -1,0 +1,12 @@
+{
+    "attr-Thermostat-Mode": {
+        "comment": "Received mode from thermostat",
+        "comment2": "Tcharp38: Can we map on a Zigbee standard attribute ?",
+        "subType": "string",
+        "template": "badge",
+        "type": "info",
+        "logicalId": "#EP#-mode",
+        "unit": "",
+        "genericType": "THERMOSTAT_MODE"
+    }
+}

--- a/core/config/commands/attr-Thermostat-Setpoint.json
+++ b/core/config/commands/attr-Thermostat-Setpoint.json
@@ -1,0 +1,15 @@
+{
+    "attr-Thermostat-Setpoint": {
+        "comment": "Received Setpoint from thermostat",
+        "comment2": "Tcharp38: Can we map on a Zigbee standard attribute ?",
+        "subType": "numeric",
+        "template": "badge",
+        "configuration": {
+            "historizeRound": "1"
+        },
+        "type": "info",
+        "logicalId": "#EP#-setpoint",
+        "unit": "\u00b0C",
+        "genericType": "THERMOSTAT_SETPOINT"
+    }
+}

--- a/core/config/commands/cmdG-TuyaEF00-Set-OnOff.json
+++ b/core/config/commands/cmdG-TuyaEF00-Set-OnOff.json
@@ -1,0 +1,12 @@
+{
+    "cmdG-TuyaEF00-Set-OnOff": {
+        "subType": "other",
+        "template": "",
+        "configuration": {
+            "topic": "cmd-tuyaEF00",
+            "request": "ep=#EP#&cmd=setOnOff&data=#ONOFF#"
+        },
+        "type": "action",
+        "genericType": "GENERIC_ACTION"
+    }
+}

--- a/core/config/commands/cmdG-TuyaEF00-Set-Setpoint.json
+++ b/core/config/commands/cmdG-TuyaEF00-Set-Setpoint.json
@@ -1,0 +1,15 @@
+{
+    "cmdG-TuyaEF00-Set-Setpoint": {
+        "isVisible": 0,
+        "subType": "slider",
+        "template": "",
+        "configuration": {
+            "topic": "cmd-tuyaEF00",
+            "request": "ep=#EP#&cmd=setSetpoint&data=#slider#",
+            "minValue": 0,
+            "maxValue": 30
+        },
+        "type": "action",
+        "genericType": "THERMOSTAT_SET_SETPOINT"
+    }
+}

--- a/core/config/commands/cmdG-TuyaEF00-Set-ThermostatMode.json
+++ b/core/config/commands/cmdG-TuyaEF00-Set-ThermostatMode.json
@@ -1,0 +1,12 @@
+{
+    "cmdG-TuyaEF00-Set-ThermostatMode": {
+        "subType": "other",
+        "template": "",
+        "configuration": {
+            "topic": "cmd-tuyaEF00",
+            "request": "ep=#EP#&cmd=setThermostat-Mode&data=#MODE#"
+        },
+        "type": "action",
+        "genericType": "GENERIC_ACTION"
+    }
+}

--- a/core/config/commands/colorBleu.json
+++ b/core/config/commands/colorBleu.json
@@ -5,14 +5,12 @@
         "isHistorized": "0",
         "subType": "numeric",
         "template": "badge",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "visibilityCategory": "additionalCommand"
         },
         "type": "info",
         "logicalId": "colorBleu",
-        "unit": ""
+        "unit": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/colorRouge.json
+++ b/core/config/commands/colorRouge.json
@@ -5,14 +5,12 @@
         "isHistorized": "0",
         "subType": "numeric",
         "template": "badge",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "visibilityCategory": "additionalCommand"
         },
         "type": "info",
         "logicalId": "colorRouge",
-        "unit": ""
+        "unit": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/colorVert.json
+++ b/core/config/commands/colorVert.json
@@ -5,14 +5,12 @@
         "isHistorized": "0",
         "subType": "numeric",
         "template": "badge",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "visibilityCategory": "additionalCommand"
         },
         "type": "info",
         "logicalId": "colorVert",
-        "unit": ""
+        "unit": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/danfossTemperatureConsigneSet.json
+++ b/core/config/commands/danfossTemperatureConsigneSet.json
@@ -13,10 +13,8 @@
             "maxValue": "30",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/danfossUIDisplayModeSet.json
+++ b/core/config/commands/danfossUIDisplayModeSet.json
@@ -12,9 +12,7 @@
             "maxValue": "1",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/danfossUIKeyLockSet.json
+++ b/core/config/commands/danfossUIKeyLockSet.json
@@ -12,9 +12,7 @@
             "maxValue": "1",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/levelVoletStop.json
+++ b/core/config/commands/levelVoletStop.json
@@ -6,15 +6,13 @@
         "invertBinary": "0",
         "template": "",
         "isVisible": 1,
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "topic": "setLevelStop",
             "request": "1",
             "visibilityCategory": "All"
         },
         "type": "action",
-        "genericType": "FLAP_STOP"
+        "genericType": "FLAP_STOP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/luminosite.json
+++ b/core/config/commands/luminosite.json
@@ -10,12 +10,10 @@
             "visibilityCategory": "All",
             "historizeRound": "0"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
         "logicalId": "0400-#EP#-0000",
         "unit": "Lux",
-        "genericType": "BRIGHTNESS"
+        "genericType": "BRIGHTNESS",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/luminositeHue.json
+++ b/core/config/commands/luminositeHue.json
@@ -11,12 +11,10 @@
             "calculValueOffset": "pow(10,#value#\/10000+1\/10000)",
             "historizeRound": "0"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
         "logicalId": "0400-#EP#-0000",
         "unit": "Lux",
-        "genericType": "BRIGHTNESS"
+        "genericType": "BRIGHTNESS",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroup.json
+++ b/core/config/commands/onGroup.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupBroadcast.json
+++ b/core/config/commands/onGroupBroadcast.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP1.json
+++ b/core/config/commands/onGroupEP1.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP3.json
+++ b/core/config/commands/onGroupEP3.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP4.json
+++ b/core/config/commands/onGroupEP4.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP5.json
+++ b/core/config/commands/onGroupEP5.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP6.json
+++ b/core/config/commands/onGroupEP6.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP7.json
+++ b/core/config/commands/onGroupEP7.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/onGroupEP8.json
+++ b/core/config/commands/onGroupEP8.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom-lumiere-on\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/online.json
+++ b/core/config/commands/online.json
@@ -1,8 +1,8 @@
 {
     "online": {
         "isVisible": 0,
-        "name": "online",
-        "isHistorized": "1",
+        "name": "Online",
+        "isHistorized": "0",
         "subType": "binary",
         "invertBinary": "0",
         "template": "",

--- a/core/config/commands/pression.json
+++ b/core/config/commands/pression.json
@@ -7,9 +7,6 @@
         "subType": "numeric",
         "invertBinary": "0",
         "template": "barometre",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "calculValueOffset": "#value#\/10",
             "historizeRound": "1",
@@ -18,6 +15,7 @@
         "type": "info",
         "logicalId": "0403-01-0010",
         "unit": "hPa",
-        "genericType": "PRESSURE"
+        "genericType": "PRESSURE",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/pression1.json
+++ b/core/config/commands/pression1.json
@@ -7,15 +7,13 @@
         "subType": "numeric",
         "invertBinary": "0",
         "template": "badge",
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "visibilityCategory": "All"
         },
         "type": "info",
         "logicalId": "0403-01-0000",
         "unit": "hPa",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/sceneGroupRecall3.json
+++ b/core/config/commands/sceneGroupRecall3.json
@@ -11,9 +11,7 @@
             "request": "groupID=#addrGroup#&sceneID=03",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setBleu.json
+++ b/core/config/commands/setBleu.json
@@ -12,10 +12,8 @@
             "request": "EP=#EP#&color=#slider#",
             "visibilityCategory": "additionalCommand"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setColourRGB.json
+++ b/core/config/commands/setColourRGB.json
@@ -10,10 +10,10 @@
             "visibilityCategory": "additionalCommand"
         },
         "display": {
-            "forceReturnLineAfter": "1",
             "title_placeholder": "RRGGBB",
             "message_placeholder": "na"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandDimmerOff.json
+++ b/core/config/commands/setLegrandDimmerOff.json
@@ -10,9 +10,7 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandDimmerOn.json
+++ b/core/config/commands/setLegrandDimmerOn.json
@@ -10,9 +10,7 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandLEDOff.json
+++ b/core/config/commands/setLegrandLEDOff.json
@@ -11,8 +11,6 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandLEDOff_if_on.json
+++ b/core/config/commands/setLegrandLEDOff_if_on.json
@@ -11,8 +11,6 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandLEDOn.json
+++ b/core/config/commands/setLegrandLEDOn.json
@@ -11,8 +11,6 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLegrandLEDOn_if_on.json
+++ b/core/config/commands/setLegrandLEDOn_if_on.json
@@ -11,8 +11,6 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroup.json
+++ b/core/config/commands/setLevelGroup.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP1.json
+++ b/core/config/commands/setLevelGroupEP1.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP3.json
+++ b/core/config/commands/setLevelGroupEP3.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP4.json
+++ b/core/config/commands/setLevelGroupEP4.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP5.json
+++ b/core/config/commands/setLevelGroupEP5.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP6.json
+++ b/core/config/commands/setLevelGroupEP6.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP7.json
+++ b/core/config/commands/setLevelGroupEP7.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLevelGroupEP8.json
+++ b/core/config/commands/setLevelGroupEP8.json
@@ -11,9 +11,7 @@
             "request": "Level=#slider#&duration=01",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLivoloOff2.json
+++ b/core/config/commands/setLivoloOff2.json
@@ -6,15 +6,13 @@
         "invertBinary": "0",
         "template": "",
         "isVisible": 1,
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "topic": "setLevelRaw",
             "request": "EP=#EP#&Level=1&duration=02",
             "visibilityCategory": "All"
         },
         "type": "action",
-        "genericType": "LIGHT_OFF"
+        "genericType": "LIGHT_OFF",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setLivoloOn2.json
+++ b/core/config/commands/setLivoloOn2.json
@@ -6,15 +6,13 @@
         "invertBinary": "0",
         "template": "",
         "isVisible": 1,
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "configuration": {
             "topic": "setLevelRaw",
             "request": "EP=#EP#&Level=108&duration=02",
             "visibilityCategory": "All"
         },
         "type": "action",
-        "genericType": "LIGHT_ON"
+        "genericType": "LIGHT_ON",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setRGB.json
+++ b/core/config/commands/setRGB.json
@@ -11,10 +11,10 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "forceReturnLineAfter": "1",
             "visibilityCategory": "additionalCommand"
         },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR"
+        "genericType": "LIGHT_SET_COLOR",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setReportLightColorSpectre.json
+++ b/core/config/commands/setReportLightColorSpectre.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 11
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setRouge.json
+++ b/core/config/commands/setRouge.json
@@ -12,10 +12,8 @@
             "request": "EP=#EP#&color=#slider#",
             "visibilityCategory": "additionalCommand"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setSmokeSensivityHigh.json
+++ b/core/config/commands/setSmokeSensivityHigh.json
@@ -9,9 +9,7 @@
             "request": "Proprio=115f&clusterId=0500&attributeId=fff1&attributeType=23&value=04030000&repeat=3",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLight.json
+++ b/core/config/commands/setTemperatureLight.json
@@ -13,10 +13,8 @@
             "maxValue": "4000",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLight1.json
+++ b/core/config/commands/setTemperatureLight1.json
@@ -13,10 +13,8 @@
             "maxValue": "5000",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLight2.json
+++ b/core/config/commands/setTemperatureLight2.json
@@ -13,10 +13,8 @@
             "maxValue": "6500",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLightGroup.json
+++ b/core/config/commands/setTemperatureLightGroup.json
@@ -13,10 +13,8 @@
             "maxValue": "4000",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLight_1700_4900.json
+++ b/core/config/commands/setTemperatureLight_1700_4900.json
@@ -14,9 +14,7 @@
             "maxValue": "4900",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setTemperatureLight_2700_6500.json
+++ b/core/config/commands/setTemperatureLight_2700_6500.json
@@ -13,10 +13,8 @@
             "maxValue": "6500",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "LIGHT_SET_COLOR_TEMP"
+        "genericType": "LIGHT_SET_COLOR_TEMP",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setVert.json
+++ b/core/config/commands/setVert.json
@@ -12,10 +12,8 @@
             "request": "EP=#EP#&color=#slider#",
             "visibilityCategory": "additionalCommand"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/setVibrationSensivityHigh.json
+++ b/core/config/commands/setVibrationSensivityHigh.json
@@ -10,9 +10,7 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "Network"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritHostFlagsBoostSet.json
+++ b/core/config/commands/spiritHostFlagsBoostSet.json
@@ -11,10 +11,8 @@
             "request": "clusterId=0201&attributeId=4008&EP=01&Proprio=1037&attributeType=22&value=000044",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritHostFlagsChildLockSet.json
+++ b/core/config/commands/spiritHostFlagsChildLockSet.json
@@ -11,10 +11,8 @@
             "request": "clusterId=0201&attributeId=4008&EP=01&Proprio=1037&attributeType=22&value=000080",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritHostFlagsDefaultSet.json
+++ b/core/config/commands/spiritHostFlagsDefaultSet.json
@@ -11,10 +11,8 @@
             "request": "clusterId=0201&attributeId=4008&EP=01&Proprio=1037&attributeType=22&value=000000",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritHostFlagsDisplayDownSet.json
+++ b/core/config/commands/spiritHostFlagsDisplayDownSet.json
@@ -11,10 +11,8 @@
             "request": "clusterId=0201&attributeId=4008&EP=01&Proprio=1037&attributeType=22&value=000002",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritHostFlagsOffSet.json
+++ b/core/config/commands/spiritHostFlagsOffSet.json
@@ -11,10 +11,8 @@
             "request": "clusterId=0201&attributeId=4008&EP=01&Proprio=1037&attributeType=22&value=000020",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritTemperatureBindShortToZigate.json
+++ b/core/config/commands/spiritTemperatureBindShortToZigate.json
@@ -13,9 +13,7 @@
             "execAtCreation": "Yes",
             "execAtCreationDelay": 9
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritTemperatureConsigneSet.json
+++ b/core/config/commands/spiritTemperatureConsigneSet.json
@@ -13,10 +13,8 @@
             "maxValue": "30",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritTrvModeSet.json
+++ b/core/config/commands/spiritTrvModeSet.json
@@ -13,10 +13,8 @@
             "maxValue": "255",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritTrvModeSetManu.json
+++ b/core/config/commands/spiritTrvModeSetManu.json
@@ -13,10 +13,8 @@
             "maxValue": "255",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritTrvModeSetValve.json
+++ b/core/config/commands/spiritTrvModeSetValve.json
@@ -13,10 +13,8 @@
             "maxValue": "255",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/spiritValvePositionSet.json
+++ b/core/config/commands/spiritValvePositionSet.json
@@ -13,10 +13,8 @@
             "maxValue": "255",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": ""
+        "genericType": "",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/temperatureLightV2.json
+++ b/core/config/commands/temperatureLightV2.json
@@ -10,11 +10,9 @@
             "historizeRound": "0",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
         "logicalId": "0300-#EP#-0007",
-        "unit": "K"
+        "unit": "K",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/toggleVolet.json
+++ b/core/config/commands/toggleVolet.json
@@ -11,9 +11,7 @@
             "request": "Toggle",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/upGroup.json
+++ b/core/config/commands/upGroup.json
@@ -12,9 +12,9 @@
             "visibilityCategory": "All"
         },
         "display": {
-            "icon": "<i class=\"icon jeedom2-bright4\"><\/i>",
-            "forceReturnLineAfter": "1"
+            "icon": "<i class=\"icon jeedom2-bright4\"><\/i>"
         },
-        "type": "action"
+        "type": "action",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/vibrationAngle.json
+++ b/core/config/commands/vibrationAngle.json
@@ -8,10 +8,8 @@
             "repeatEventManagement": "always",
             "visibilityCategory": "All"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "info",
-        "logicalId": "0101-#EP#-0503"
+        "logicalId": "0101-#EP#-0503",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/writeAttributeRequestIAS_WD_Flash.json
+++ b/core/config/commands/writeAttributeRequestIAS_WD_Flash.json
@@ -10,10 +10,8 @@
             "topic": "writeAttributeRequestIAS_WD",
             "request": "mode=Flash&duration=#slider#"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/writeAttributeRequestIAS_WD_FlashSound.json
+++ b/core/config/commands/writeAttributeRequestIAS_WD_FlashSound.json
@@ -10,10 +10,8 @@
             "topic": "writeAttributeRequestIAS_WD",
             "request": "mode=FlashSound&duration=#slider#"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/writeAttributeRequestIAS_WD_Sound.json
+++ b/core/config/commands/writeAttributeRequestIAS_WD_Sound.json
@@ -10,10 +10,8 @@
             "topic": "writeAttributeRequestIAS_WD",
             "request": "mode=Sound&duration=#slider#"
         },
-        "display": {
-            "forceReturnLineAfter": "1"
-        },
         "type": "action",
-        "genericType": "DONT"
+        "genericType": "DONT",
+        "nextLine": "after"
     }
 }

--- a/core/config/commands/zb-0402-MeasuredValue.json
+++ b/core/config/commands/zb-0402-MeasuredValue.json
@@ -5,7 +5,7 @@
         "comment3": "Derived from obsolete 'temperature.json'",
         "name": "MeasuredValue",
         "subType": "numeric",
-        "template": "tempIMG",
+        "template": "badge",
         "configuration": {
             "calculValueOffset": "#value#\/100",
             "historizeRound": "1"

--- a/core/config/commands/zb-0405-MeasuredValue.json
+++ b/core/config/commands/zb-0405-MeasuredValue.json
@@ -5,7 +5,7 @@
         "comment3": "Based on obsolete 'humidite.json'",
         "name": "MeasuredValue",
         "subType": "numeric",
-        "template": "hydro3IMG",
+        "template": "badge",
         "configuration": {
             "calculValueOffset": "#value#\/100",
             "historizeRound": "0"

--- a/core/config/commands/zbCmdG-TuyaEF00.json
+++ b/core/config/commands/zbCmdG-TuyaEF00.json
@@ -1,0 +1,15 @@
+{
+    "zbCmdG-TuyaEF00": {
+        "isVisible": 0,
+        "isHistorized": 0,
+        "subType": "other",
+        "invertBinary": "0",
+        "template": "",
+        "configuration": {
+            "topic": "cmd-tuyaEF00",
+            "request": "ep=#EP#&dpId=#DPID#&dpType=#DPTYPE#&dpData=#DPDATA#"
+        },
+        "type": "action",
+        "genericType": ""
+    }
+}

--- a/core/config/devices/LOM001/LOM001.json
+++ b/core/config/devices/LOM001/LOM001.json
@@ -11,6 +11,19 @@
         },
         "type": "Philips Hue Smart Plug",
         "commands": {
+            "SWBuildID": {
+                "use": "zb-0000-SWBuildID"
+            },
+            "Get-SWBuildID": {
+                "use": "zbReadAttribute",
+                "params": "clustId=0000&attrId=4000"
+            },
+            "Identify": {
+                "use": "Identify"
+            },
+            "Groups": {
+                "use": "Group-Membership"
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1
@@ -23,15 +36,17 @@
                 "use": "zbCmd-0006-Off",
                 "isVisible": 1
             },
+            "Toggle": {
+                "use": "zbCmd-0006-Toggle",
+                "nextLine": "after"
+            },
             "Get-Status": {
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
-                "params": "clustId=0008",
+                "params": "clustId=0006",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
@@ -46,17 +61,6 @@
                 "params": "clustId=0008&attrType=20&attrId=0000&minInterval=0000&maxInterval=0000&changeVal=",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 11
-            },
-            "SWBuildID": {
-                "use": "zb-0000-SWBuildID"
-            },
-            "Get-SWBuildID": {
-                "use": "zbReadAttribute",
-                "params": "clustId=0000&attrId=4000"
-            },
-            "Toggle": {
-                "use": "zbCmd-0006-Toggle",
-                "nextLine": "after"
             }
         }
     }

--- a/core/config/devices/LOM002/LOM002.json
+++ b/core/config/devices/LOM002/LOM002.json
@@ -11,6 +11,19 @@
         },
         "type": "Philips Hue Smart Plug",
         "commands": {
+            "SWBuildID": {
+                "use": "zb-0000-SWBuildID"
+            },
+            "Get-SWBuildID": {
+                "use": "zbReadAttribute",
+                "params": "clustId=0000&attrId=4000"
+            },
+            "Identify": {
+                "use": "Identify"
+            },
+            "Groups": {
+                "use": "Group-Membership"
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1
@@ -23,15 +36,17 @@
                 "use": "zbCmd-0006-Off",
                 "isVisible": 1
             },
+            "Toggle": {
+                "use": "zbCmd-0006-Toggle",
+                "nextLine": "after"
+            },
             "Get-Status": {
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
-                "params": "clustId=0008",
+                "params": "clustId=0006",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 9
             },
@@ -46,17 +61,6 @@
                 "params": "clustId=0008&attrType=20&attrId=0000&minInterval=0000&maxInterval=0000&changeVal=",
                 "execAtCreation": "Yes",
                 "execAtCreationDelay": 11
-            },
-            "SWBuildID": {
-                "use": "zb-0000-SWBuildID"
-            },
-            "Get-SWBuildID": {
-                "use": "zbReadAttribute",
-                "params": "clustId=0000&attrId=4000"
-            },
-            "Toggle": {
-                "use": "zbCmd-0006-Toggle",
-                "nextLine": "after"
             }
         }
     }

--- a/core/config/devices/LOM007/LOM007.json
+++ b/core/config/devices/LOM007/LOM007.json
@@ -1,0 +1,59 @@
+{
+    "LOM007": {
+        "manufacturer": "Philips",
+        "model": "LOM007",
+        "type": "Philips Hue Smart Plug EU",
+        "category": {
+            "automatism": "1"
+        },
+        "configuration": {
+            "icon": "LOM001",
+            "mainEP": "0B"
+        },
+        "commands": {
+            "SWBuildID": {
+                "use": "zb-0000-SWBuildID"
+            },
+            "Get SWBuildID": {
+                "use": "zbReadAttribute",
+                "params": "clustId=0000&attrId=4000"
+            },
+            "Identify": {
+                "use": "Identify"
+            },
+            "Groups": {
+                "use": "Group-Membership"
+            },
+            "On": {
+                "use": "zbCmd-0006-On",
+                "isVisible": "1"
+            },
+            "Off": {
+                "use": "zbCmd-0006-Off",
+                "isVisible": "1"
+            },
+            "Toggle": {
+                "use": "zbCmd-0006-Toggle"
+            },
+            "Status": {
+                "use": "zb-0006-OnOff",
+                "isVisible": "1",
+                "nextLine": "after"
+            },
+            "Get Status": {
+                "use": "zbReadAttribute",
+                "params": "clustId=0006&attrId=0000"
+            },
+            "Bind 0006-ToZigate": {
+                "use": "zbBindToZigate",
+                "params": "clustId=0006",
+                "execAtCreation": "yes"
+            },
+            "SetReporting 0006": {
+                "use": "zbConfigureReporting",
+                "params": "clustId=0006&attrType=10&attrId=0000&minInterval=0000&maxInterval=0000&changeVal=",
+                "execAtCreation": "yes"
+            }
+        }
+    }
+}

--- a/core/config/devices/LOM007/discovery.json
+++ b/core/config/devices/LOM007/discovery.json
@@ -1,0 +1,179 @@
+{
+    "endPoints": {
+        "0B": {
+            "servClusters": {
+                "0000": {
+                    "attributes": {
+                        "0005": {
+                            "value": "LOM007"
+                        },
+                        "0000": {
+                            "value": 2
+                        },
+                        "0001": {
+                            "value": 2
+                        },
+                        "0002": {
+                            "value": 1
+                        },
+                        "0003": {
+                            "value": 1
+                        },
+                        "0004": {
+                            "value": "SignifyNetherlandsB.V."
+                        },
+                        "0006": {
+                            "value": "20201117"
+                        },
+                        "0007": {
+                            "value": 1
+                        },
+                        "0008": {
+                            "value": 0
+                        },
+                        "0009": {
+                            "value": 255
+                        },
+                        "000A": {
+                            "value": ""
+                        },
+                        "000B": {
+                            "value": "www.meethue.com"
+                        },
+                        "4000": {
+                            "value": "1.76.11"
+                        },
+                        "FFFD": {
+                            "value": 1
+                        }
+                    }
+                },
+                "0003": {
+                    "attributes": {
+                        "0000": {
+                            "value": 171
+                        },
+                        "FFFD": {
+                            "value": 1
+                        }
+                    }
+                },
+                "0004": {
+                    "attributes": {
+                        "0000": {
+                            "value": "00"
+                        },
+                        "FFFD": {
+                            "value": 1
+                        }
+                    }
+                },
+                "0005": {
+                    "attributes": {
+                        "0000": {
+                            "dataType": "20",
+                            "value": 0
+                        },
+                        "0001": {
+                            "dataType": "20",
+                            "value": 0
+                        },
+                        "0002": {
+                            "dataType": "21",
+                            "value": 0
+                        },
+                        "0003": {
+                            "dataType": "10",
+                            "value": 0
+                        },
+                        "0004": {
+                            "dataType": "18",
+                            "value": 0
+                        },
+                        "FFFD": {
+                            "dataType": "21",
+                            "value": 1
+                        }
+                    }
+                },
+                "0006": {
+                    "attributes": {
+                        "0000": {
+                            "value": 1
+                        },
+                        "4000": {
+                            "value": 1
+                        },
+                        "4001": {
+                            "value": 0
+                        },
+                        "4002": {
+                            "value": 0
+                        },
+                        "4003": {
+                            "value": 255
+                        },
+                        "FFFD": {
+                            "value": 1
+                        }
+                    }
+                },
+                "0008": {
+                    "attributes": {
+                        "0000": {
+                            "value": 254
+                        },
+                        "0001": {
+                            "value": 0
+                        },
+                        "000F": {
+                            "value": "00"
+                        },
+                        "4000": {
+                            "value": 255
+                        },
+                        "FFFD": {
+                            "value": 1
+                        }
+                    }
+                },
+                "1000": {
+                    "attributes": {
+                        "FFFD": {
+                            "dataType": "21",
+                            "value": 1
+                        }
+                    }
+                },
+                "FC02": {
+                    "attributes": []
+                }
+            },
+            "status": "00",
+            "cliClusters": {
+                "0019": {
+                    "attributes": {
+                        "0000": [],
+                        "0001": [],
+                        "0002": [],
+                        "0003": [],
+                        "0004": [],
+                        "0006": [],
+                        "0007": [],
+                        "0008": [],
+                        "0009": [],
+                        "FFFD": []
+                    }
+                }
+            }
+        },
+        "F2": {
+            "status": "00",
+            "cliClusters": {
+                "0021": {
+                    "attributes": []
+                }
+            }
+        }
+    }
+}

--- a/core/config/devices/TS0201/TS0201.json
+++ b/core/config/devices/TS0201/TS0201.json
@@ -1,5 +1,8 @@
 {
     "TS0201": {
+        "manufacturer": "Blitzwolf",
+        "model": "BW-IS4",
+        "type": "Blitzwolf Temperature and Humidity sensor & display",
         "timeout": "60",
         "configuration": {
             "mainEP": "01",
@@ -8,23 +11,23 @@
         "category": {
             "automatism": "1"
         },
-        "type": "Wireless Temperature and Humidity",
         "commands": {
+            "SWBuildID": {
+                "use": "zb-0000-SWBuildID"
+            },
+
+            "include5": "Batterie-Volt-Konke",
+            "Battery-Percent": {
+                "use": "zb-0001-BatteryPercent"
+            },
+
             "Temperature": {
                 "use": "zb-0402-MeasuredValue",
                 "isVisible": 1,
                 "isHistorized": 1
             },
-            "Humidity": { "use": "zb-0405-MeasuredValue", "isVisible": 1 },
-            "include5": "Batterie-Volt-Konke",
-            "Battery-Percent": {
-                "use": "zb-0001-BatteryPercent",
-                "isVisible": 1
-            },
-            "SWBuildID": {
-                "use": "zb-0000-SWBuildID"
-            }
-        },
-        "comment": ""
+
+            "Humidity": { "use": "zb-0405-MeasuredValue", "isVisible": 1 }
+        }
     }
 }

--- a/core/config/devices/TS0601__TZE200_hue3yfsn/TS0601__TZE200_hue3yfsn.json
+++ b/core/config/devices/TS0601__TZE200_hue3yfsn/TS0601__TZE200_hue3yfsn.json
@@ -2,19 +2,78 @@
     "TS0601__TZE200_hue3yfsn": {
         "manufacturer": "Tuya",
         "model": "TV02",
-        "comment": "Empty model. Need to understand how to use cluster EF00",
         "timeout": "60",
         "configuration": {
             "mainEP": "01",
             "icon": "Tuya-TV02",
-            "batteryType": "To be defined"
+            "batteryType": "2x1.5V AA"
         },
         "category": {
             "heating": "1"
         },
         "type": "Tuya TV02",
         "commands": {
-            "Groups": { "use": "Group-Membership" }
+            "Battery-Percent": { "use": "zb-0001-BatteryPercent" },
+            "Groups": { "use": "Group-Membership" },
+            "Temperature": {
+                "use": "zb-0402-MeasuredValue",
+                "isVisible": 1
+            },
+            "Window-Detection": {
+                "use": "attr-Door-Status",
+                "logicalId": "01-windowDetectionStatus",
+                "nextLine": "after",
+                "isVisible": 1
+            },
+            "Set Setpoint": {
+                "use": "cmdG-TuyaEF00-Set-Setpoint",
+                "isVisible": 1
+            },
+            "Setpoint": {
+                "use": "attr-Thermostat-Setpoint",
+                "isVisible": 1
+            },
+            "Manual": {
+                "use": "cmdG-TuyaEF00-Set-ThermostatMode",
+                "params": "mode=01",
+                "isVisible": 1
+            },
+            "Auto": {
+                "use": "cmdG-TuyaEF00-Set-ThermostatMode",
+                "params": "mode=00",
+                "isVisible": 1
+            },
+            "Mode": {
+                "use": "attr-Thermostat-Mode",
+                "nextLine": "after",
+                "isVisible": 1
+            },
+            "Check ON": {
+                "use": "cmdG-TuyaEF00-Set-OnOff",
+                "params": "onOff=01",
+                "comment": "Purpose not clear",
+                "isVisible": 1
+            },
+            "Check OFF": {
+                "use": "cmdG-TuyaEF00-Set-OnOff",
+                "params": "onOff=00",
+                "comment": "Purpose not clear",
+                "isVisible": 1
+            },
+            "Status": {
+                "use": "zb-0006-OnOff",
+                "isVisible": 1
+            }
+       },
+        "tuyaEF00": {
+            "fromDevice": {
+                "02": "rcvThermostat-Mode",
+                "08": "rcvThermostat-WindowDetectionStatus",
+                "10": "rcvThermostat-Setpoint",
+                "18": "rcvThermostat-LocalTemp",
+                "23": "rcvBattery-Percent",
+                "73": "rcvOnline-Status"
+            }
         }
     }
 }

--- a/core/config/devices/TS0601__TZE200_yvx5lh6k/TS0601__TZE200_yvx5lh6k.json
+++ b/core/config/devices/TS0601__TZE200_yvx5lh6k/TS0601__TZE200_yvx5lh6k.json
@@ -23,25 +23,39 @@
             },
             "Humidity": {
                 "use": "zb-0405-MeasuredValue",
+                "nextLine": "after",
                 "isVisible": 1
             },
             "CO2": {
                 "use": "zb-CustomInfo",
                 "logicalId": "01-CO2_ppm",
                 "unit": "ppm",
+                "template": "badge",
                 "isVisible": 1
             },
             "VOC": {
                 "use": "zb-CustomInfo",
                 "logicalId": "01-VOC_ppm",
                 "unit": "ppm",
+                "template": "badge",
+                "nextLine": "after",
                 "isVisible": 1
             },
             "CH20": {
                 "use": "zb-CustomInfo",
                 "logicalId": "01-CH20_ppm",
                 "unit": "ppm",
+                "template": "badge",
                 "isVisible": 1
+            }
+        },
+        "tuyaEF00": {
+            "fromDevice": {
+                "02": "rcvSmartAir-CO2",
+                "12": "rcvSmartAir-Temperature",
+                "13": "rcvSmartAir-Humidity",
+                "15": "rcvSmartAir-VOC",
+                "16": "rcvSmartAir-CH20"
             }
         }
     }

--- a/core/config/rucheCommand.json
+++ b/core/config/rucheCommand.json
@@ -1,7 +1,33 @@
 {
+    "online": {
+        "name": "Online",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "SW-Application": {
+        "name": "SW",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "SW-SDK": {
+        "name": "SDK",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
     "Get FW version": {
         "name": "Get FW version",
-        "order": 0,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -9,14 +35,40 @@
         "configuration": {
             "topic": "getZgVersion",
             "request": ""
-        },
+        }
+    },
+    "Time-Time": {
+        "name": "Last",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "Time-TimeStamp": {
+        "name": "Last Stamps",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "ZiGate-Time": {
+        "name": "ZiGate-Time",
+        "isHistorized": "0",
+        "isVisible": "0",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": "",
         "display": {
             "forceReturnLineAfter": "1"
         }
     },
     "Get Network Status": {
         "name": "Get Network Status",
-        "order": 2,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -24,14 +76,46 @@
         "configuration": {
             "topic": "getNetworkStatus",
             "request": "getNetworkStatus"
-        },
-        "display": {
-            "forceReturnLineAfter": "1"
         }
+    },
+    "Short-Addr": {
+        "name": "Short Addr",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "IEEE-Addr": {
+        "name": "IEEE Addr",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "PAN-ID": {
+        "name": "PAN ID",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
+    },
+    "Ext_PAN-ID": {
+        "name": "Ext PAN ID",
+        "isHistorized": "0",
+        "isVisible": "1",
+        "Type": "info",
+        "subType": "string",
+        "invertBinary": "0",
+        "template": ""
     },
     "Inclusion": {
         "name": "Inclusion",
-        "order": 3,
         "isHistorized": "0",
         "isVisible": "1",
         "Type": "action",
@@ -43,7 +127,6 @@
     },
     "Get Inclusion Status": {
         "name": "Get Inclusion Status",
-        "order": 4,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -58,7 +141,6 @@
     },
     "permitJoin-Status": {
         "name": "Inclusion Status",
-        "order": 5,
         "isHistorized": "0",
         "isVisible": "1",
         "Type": "info",
@@ -71,7 +153,6 @@
     },
     "addGroup": {
         "name": "Add Group",
-        "order": 8,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -87,7 +168,6 @@
     },
     "removeGroup": {
         "name": "Remove Group",
-        "order": 9,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -104,7 +184,6 @@
     },
     "getGroupMemberShip": {
         "name": "getGroupMemberShip",
-        "order": 10,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -121,7 +200,6 @@
     },
     "storeScene": {
         "name": "storeScene",
-        "order": 11,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -138,7 +216,6 @@
     },
     "recallScene": {
         "name": "recallScene",
-        "order": 12,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -155,7 +232,6 @@
     },
     "sceneGroupRecall": {
         "name": "sceneGroupRecall",
-        "order": 13,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -172,7 +248,6 @@
     },
     "addScene": {
         "name": "Add Scene",
-        "order": 14,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -188,7 +263,6 @@
     },
     "removeScene": {
         "name": "Remove Scene",
-        "order": 15,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -205,7 +279,6 @@
     },
     "removeSceneAll": {
         "name": "Remove Scene All",
-        "order": 16,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -222,7 +295,6 @@
     },
     "viewScene": {
         "name": "viewScene",
-        "order": 17,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -239,7 +311,6 @@
     },
     "getSceneMemberShip": {
         "name": "getSceneMemberShip",
-        "order": 18,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -254,89 +325,8 @@
             "message_placeholder": "DestinationEndPoint=XX&groupID=YYYY"
         }
     },
-    "Time-Time": {
-        "name": "Last",
-        "order": 28,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "Time-TimeStamp": {
-        "name": "Last Stamps",
-        "order": 29,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "SW-Application": {
-        "name": "SW",
-        "order": 30,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "SW-SDK": {
-        "name": "SDK",
-        "order": 31,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
     "Network-Status": {
         "name": "Network Status",
-        "order": 32,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "Short-Addr": {
-        "name": "Short Addr",
-        "order": 33,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "PAN-ID": {
-        "name": "PAN ID",
-        "order": 34,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "Ext_PAN-ID": {
-        "name": "Ext PAN ID",
-        "order": 35,
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "IEEE-Addr": {
-        "name": "IEEE Addr",
-        "order": 36,
         "isHistorized": "0",
         "isVisible": "1",
         "Type": "info",
@@ -346,7 +336,6 @@
     },
     "Network-Channel": {
         "name": "Network Channel",
-        "order": 37,
         "isHistorized": "0",
         "isVisible": "1",
         "Type": "info",
@@ -356,7 +345,6 @@
     },
     "Network Status Request": {
         "name": "Network Status Request (Not implemented)",
-        "order": 38,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -368,7 +356,6 @@
     },
     "joinLeave-IEEE": {
         "name": "joinLeave",
-        "order": 39,
         "isHistorized": "1",
         "isVisible": "0",
         "Type": "info",
@@ -376,24 +363,8 @@
         "invertBinary": "0",
         "template": ""
     },
-    "Reset": {
-        "name": "Reset",
-        "order": 42,
-        "isHistorized": "0",
-        "isVisible": "0",
-        "Type": "action",
-        "subType": "other",
-        "configuration": {
-            "topic": "reset",
-            "request": "reset"
-        },
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
-    },
     "Factory New Reset": {
         "name": "Factory New Reset",
-        "order": 44,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -406,26 +377,8 @@
             "forceReturnLineAfter": "1"
         }
     },
-    "replaceEquipement": {
-        "name": "Replace Equipement",
-        "order": 45,
-        "isHistorized": "0",
-        "isVisible": "0",
-        "Type": "action",
-        "subType": "message",
-        "configuration": {
-            "topic": "replaceEquipement",
-            "request": "old=#title#&new=#message#"
-        },
-        "display": {
-            "forceReturnLineAfter": "0",
-            "title_placeholder": "Adresse courte de l ancien equipement",
-            "message_placeholder": "Adresse courte du nouvel equipement"
-        }
-    },
     "Network-Bind": {
         "name": "Last Bind",
-        "order": 46,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "info",
@@ -435,7 +388,6 @@
     },
     "Network-Report": {
         "name": "Last Report",
-        "order": 47,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "info",
@@ -445,7 +397,6 @@
     },
     "Network_Address_request": {
         "name": "Network Address Request",
-        "order": 49,
         "isHistorized": "0",
         "isVisible": "0",
         "Type": "action",
@@ -458,42 +409,6 @@
             "forceReturnLineAfter": "0",
             "title_placeholder": "Adresse courte de l equipement",
             "message_placeholder": "IEEEAddress=xxxxxxxxxxxxxxxx[&requestType=00&startIndex=00] "
-        }
-    },
-    "Set Time": {
-        "name": "Set Zigate-Time",
-        "order": 51,
-        "isHistorized": "0",
-        "isVisible": "0",
-        "Type": "action",
-        "subType": "other",
-        "configuration": {
-            "topic": "setZgTimeServer",
-            "request": ""
-        }
-    },
-    "ZiGate-Time": {
-        "name": "ZiGate-Time",
-        "order": 53,
-        "isHistorized": "0",
-        "isVisible": "0",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": "",
-        "display": {
-            "forceReturnLineAfter": "1"
-        }
-    },
-    "Get Time": {
-        "name": "Get Zigate-Time",
-        "isHistorized": "0",
-        "isVisible": "0",
-        "Type": "action",
-        "subType": "other",
-        "configuration": {
-            "topic": "getZgTimeServer",
-            "request": ""
         }
     },
     "Group-Membership": {
@@ -564,23 +479,5 @@
         "display": {
             "forceReturnLineAfter": "1"
         }
-    },
-    "SystemMessage": {
-        "name": "SystemMessage",
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
-    },
-    "online": {
-        "name": "online",
-        "isHistorized": "0",
-        "isVisible": "1",
-        "Type": "info",
-        "subType": "string",
-        "invertBinary": "0",
-        "template": ""
     }
 }

--- a/core/php/AbeilleCmd-Tuya.php
+++ b/core/php/AbeilleCmd-Tuya.php
@@ -1,0 +1,40 @@
+<?php
+    // Tuya specific commands (to device) functions.
+    // Included by 'AbeilleCmd.php'
+
+    // Tuya generic command (ex: 'setSetpoint') to data point mapping.
+    // Note: There is a default dpId per cmd. Can be customized from device model ("params": "dpId=XX")
+    // Note: For backward compatibility, DO NOT modify these commands. Create a new one if for ex dpType is different.
+    function tuyaCmd2Dp($abCmd) {
+        $cmd = $abCmd['cmd'];
+        $data = $abCmd['data'];
+        switch ($cmd) {
+        case "setSetpoint": // Validated on TV02 thermostat
+            $dpId = (isset($abCmd['dpId']) ? $abCmd['dpId']: "10");
+            $dpType = "02"; // 4B value
+            $dpData = sprintf("%08X", $data * 10);
+            break;
+        case "setThermostat-Mode": // Validated on TV02 thermostat
+            $dpId = (isset($abCmd['dpId']) ? $abCmd['dpId']: "02");
+            $dpType = "04"; // 1B, Enum
+            $dpData = sprintf("%02X", $data);
+            break;
+        case "setOnOff": // WORK ONGOING !! Validated on TV02 thermostat
+            $dpId = (isset($abCmd['dpId']) ? $abCmd['dpId']: "73");
+            $dpType = "01"; // 1B, Bool
+            $dpData = sprintf("%02X", $data);
+            break;
+        default:
+            return false;
+        }
+
+        $dp = array(
+            'id' => $dpId,
+            'type' => $dpType,
+            // 'dataLen' => $dpLen,
+            'data' => $dpData
+        );
+        return $dp;
+    }
+
+?>

--- a/core/php/AbeilleCmd.php
+++ b/core/php/AbeilleCmd.php
@@ -24,6 +24,7 @@
     include_once __DIR__.'/../../../../core/php/core.inc.php';
     include_once __DIR__.'/../class/AbeilleCmdQueue.class.php';
     include_once __DIR__.'/AbeilleOTA.php';
+    include_once __DIR__.'/AbeilleCmd-Tuya.php';
 
     // ***********************************************************************************************
     // MAIN

--- a/core/php/AbeilleSerialRead.php
+++ b/core/php/AbeilleSerialRead.php
@@ -30,10 +30,11 @@
     /* Tcharp38: Ouahhh. How can it handle multi-zigate ? Who is
        dealing with concurrent msg_send() on the same queue ? */
     function msgToParser($msgToSend) {
-        global $queueSerialToParser, $queueMax;
+        global $queueXToParser;
         $jsonMsg = json_encode($msgToSend);
-        if (msg_send($queueSerialToParser, 1, $jsonMsg, false, false, $errCode) == false) {
-            logMessage('debug', 'msg_send(queueSerialToParser): ERROR '.$errCode);
+        // Note: '@' to suppress PHP warning message.
+        if (@msg_send($queueXToParser, 1, $jsonMsg, false, false, $errCode) == false) {
+            logMessage('debug', 'msg_send(queueXToParser): ERROR '.$errCode);
             logMessage('debug', '  msg='.json_encode($msgToSend));
             return false;
         }
@@ -133,18 +134,17 @@
     // if (pcntl_signal(SIGTERM, "shutdown", false) != true)
     //     logMessage("error", "Erreur pcntl_signal()");
 
-    // $queueSerialToParser = msg_get_queue(queueSerialToParser);
-    $queueSerialToParser = msg_get_queue($abQueues["serialToParser"]["id"]);
-    $queueMax = $abQueues["serialToParser"]["max"];
+    $queueXToParser = msg_get_queue($abQueues["xToParser"]["id"]);
+    $queueMax = $abQueues["xToParser"]["max"];
 
     /* Inform others that i'm ready to process zigate messages */
-    $msgToSend = array(
-        'src' => 'serialread',
-        'net' => $net,
-        'type' => 'status',
-        'status' => 'ready',
-    );
-    msgToParser($msgToSend);
+    // $msgToSend = array(
+    //     'src' => 'serialRead',
+    //     'net' => $net,
+    //     'type' => 'status',
+    //     'status' => 'ready',
+    // );
+    // msgToParser($msgToSend);
 
     $transcode = false;
     $frame = ""; // Transcoded message from Zigate
@@ -205,9 +205,8 @@
                     logMessage('debug', 'ERROR: CRC: got=0x'.dechex($ccrc).', exp=0x'.dechex($ecrc).', msg='.substr($frame, 0, 12).'...'.substr($frame, -2, 2));
                 } else {
                     $msgToSend = array(
-                        'src' => 'serialread',
+                        'type' => 'serialRead',
                         'net' => $net,
-                        'type' => 'zigatemessage',
                         'msg' => $frame
                     );
                     msgToParser($msgToSend);

--- a/desktop/js/Abeille.js
+++ b/desktop/js/Abeille.js
@@ -202,7 +202,7 @@ function removeBeesJeedom(zgId) {
                     xhr.open(
                         "GET",
                         "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId=" +
-                            js_queueCtrlToParser +
+                            js_queueXToParser +
                             "&msg=type:eqRemoved_net:Abeille" +
                             zgId +
                             "_eqList:" +

--- a/desktop/modal/Abeille-OTA.modal.php
+++ b/desktop/modal/Abeille-OTA.modal.php
@@ -4,8 +4,8 @@
 
     echo '<script>var js_otaDir = "'.otaDir.'";</script>'; // PHP to JS
     $abQueues = $GLOBALS['abQueues'];
-    echo '<script>var js_queueKeyXmlToCmd = "'.$abQueues['xToCmd']['id'].'";</script>'; // PHP to JS
-    echo '<script>var js_queueCtrlToParser = "'.$abQueues['ctrlToParser']['id'].'";</script>'; // PHP to JS
+    echo '<script>var js_queueXToCmd = "'.$abQueues['xToCmd']['id'].'";</script>'; // PHP to JS
+    echo '<script>var js_queueXToParser = "'.$abQueues['ctrlToParser']['id'].'";</script>'; // PHP to JS
     echo '<script>var js_queueCtrlToCmd = "'.$abQueues['ctrlToCmd']['id'].'";</script>'; // PHP to JS
 ?>
     <div class="col-sm-8">
@@ -108,7 +108,7 @@
         payload = "manufCode="+manufCode+"_imgType="+imgType;
         // topic = "Cmd"+eqLogicId+"_cmd-0019";
         // payload = "ep="+ep+"_cmd=00_manufCode="+manufCode+"_imgType="+imgType;
-        xhr.open("GET", url+"?action=sendMsg&queueId="+js_queueKeyXmlToCmd+"&topic="+topic+"&payload="+payload, true);
+        xhr.open("GET", url+"?action=sendMsg&queueId="+js_queueXToCmd+"&topic="+topic+"&payload="+payload, true);
         xhr.send();
         xhr.onreadystatechange = function() { //Appelle une fonction au changement d'état.
           if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
@@ -116,7 +116,7 @@
             topic = "Cmd"+eqLogicId+"_otaImageNotify";
             payload = "ep="+ep+"_manufCode="+manufCode+"_imgType="+imgType;
             var xhr = new XMLHttpRequest();
-            xhr.open("GET", url+"?action=sendMsg&queueId="+js_queueKeyXmlToCmd+"&topic="+topic+"&payload="+payload, true);
+            xhr.open("GET", url+"?action=sendMsg&queueId="+js_queueXToCmd+"&topic="+topic+"&payload="+payload, true);
             xhr.send();
           }
         }
@@ -245,7 +245,7 @@
 
                 /* Asking parser to refresh its firmwares list */
                 var xhr = new XMLHttpRequest();
-                xhr.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueCtrlToParser+"&msg=type:readOtaFirmwares", true);
+                xhr.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueXToParser+"&msg=type:readOtaFirmwares", true);
                 xhr.onload = function () {
                     /* Asking cmd to refresh its firmwares list */
                     var xhr = new XMLHttpRequest();

--- a/desktop/php/Abeille.php
+++ b/desktop/php/Abeille.php
@@ -37,7 +37,7 @@
 
     sendVarToJS('eqType', 'Abeille');
     $abQueues = $GLOBALS['abQueues'];
-    echo '<script>var js_queueCtrlToParser = "'.$abQueues['ctrlToParser']['id'].'";</script>'; // PHP to JS
+    echo '<script>var js_queueXToParser = "'.$abQueues['xToParser']['id'].'";</script>'; // PHP to JS
     echo '<script>var js_queueXToCmd = "'.$abQueues['xToCmd']['id'].'";</script>'; // PHP to JS
 
     $eqLogics = eqLogic::byType('Abeille');

--- a/desktop/php/AbeilleEq-Advanced-Common.php
+++ b/desktop/php/AbeilleEq-Advanced-Common.php
@@ -27,17 +27,8 @@
     <?php
     echo '<div class="col-sm-5 cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "Last").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
         echo '<span id="idLastComm">'.getCmdValueByLogicId($eqId, "Time-Time").'</span>';
+        addJsUpdateFunction($eqId, 'Time-Time', 'idLastComm');
     ?>
-        <script>
-            <?php
-                $cmdId = getCmdIdByLogicId($eqId, "Time-Time");
-                echo "jeedom.cmd.update['".$cmdId."'] = function(_options){";
-                echo 'console.log("jeedom.cmd.update['.$cmdId.']");';
-            ?>
-                var element = document.getElementById('idLastComm');
-                element.textContent = _options.display_value;
-            }
-        </script>
     </div>
 </div>
 

--- a/desktop/php/AbeilleEq-Advanced-Zigate.php
+++ b/desktop/php/AbeilleEq-Advanced-Zigate.php
@@ -22,6 +22,38 @@
 </div>
 
 <div class="form-group">
+    <label class="col-sm-3 control-label">Firmware</label>
+    <div class="col-sm-5">
+        <?php
+        $fwVersion = getCmdValueByLogicId($eqId, "SW-Application").'-'.getCmdValueByLogicId($eqId, "SW-SDK");
+        // TODO: Currently updated only if SW-SDK change. Better to merge major & minor and have only 1 jeedom info.
+        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByLogicId($eqId, "SW-SDK").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
+            echo '<span id="idFWVersion">'.$fwVersion.'</span>';
+            echo "<script>";
+            $spanId = 'idFWVersion';
+            $cmdLogicId = 'SW-Application';
+            echo "jeedom.cmd.update['".getCmdIdByLogicId($eqId, $cmdLogicId)."'] = function(_options) {";
+                echo "console.log('jeedom.cmd.update[".$cmdLogicId."]');";
+                // console.log(_options);
+                echo "var element = document.getElementById('".$spanId."');";
+                echo "minor = element.textContent.substr(5, 4);";
+                echo "element.textContent = _options.display_value+minor;";
+            echo "}";
+            $cmdLogicId = 'SW-SDK';
+            echo "jeedom.cmd.update['".getCmdIdByLogicId($eqId, $cmdLogicId)."'] = function(_options) {";
+                echo "console.log('jeedom.cmd.update[".$cmdLogicId."]');";
+                // console.log(_options);
+                echo "var element = document.getElementById('".$spanId."');";
+                echo "major = element.textContent.substr(0, 5);";
+                echo "element.textContent = major+_options.display_value;";
+            echo "}";
+            echo "</script>";
+        echo '</div>';
+        ?>
+    </div>
+</div>
+
+<div class="form-group">
     <label class="col-sm-3 control-label">Status réseau</label>
     <div class="col-sm-5">
         <?php
@@ -30,68 +62,6 @@
             if (isset($dbgDeveloperMode))
                 echo '<a class="btn btn-warning" onclick="sendZigate(\'startNetwork\', \'\')">Démarrer</a>';
         ?>
-    </div>
-</div>
-
-<div class="form-group">
-    <label class="col-sm-3 control-label">Firmware</label>
-    <div class="col-sm-5">
-        <?php
-        $fwVersion = getCmdValueByLogicId($eqId, "SW-Application").'-'.getCmdValueByLogicId($eqId, "SW-SDK");
-        // TODO: Currently updated only if SW-SDK change. Better to merge major & minor and have only 1 jeedom info.
-        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByLogicId($eqId, "SW-SDK").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
-        echo '<span id="idFWVersion">'.$fwVersion.'</span>';
-        ?>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByLogicId($eqId, "SW-SDK")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[SDK]");
-                    // console.log(_options);
-                    var element = document.getElementById('idFWVersion');
-                    element.textContent = _options.display_value;
-                }
-            </script>
-        </div>
-    </div>
-</div>
-
-<div class="form-group">
-    <label class="col-sm-3 control-label">PAN ID</label>
-    <div class="col-sm-5">
-        <?php
-        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "PAN ID").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
-            echo '<span id="idPanId">'.getCmdValueByName($eqId, 'PAN ID').'</span>';
-        ?>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "PAN ID")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[PAN ID]");
-                    var element = document.getElementById('idPanId');
-                    element.textContent = _options.display_value;
-                }
-            </script>
-        </div>
-    </div>
-</div>
-
-<div class="form-group">
-    <div class="col-sm-3 control-label">
-        <label class="">Extended PAN ID</label>
-        <!-- <a class="btn btn-primary btn-xs" target="_blank" href="https://kiwihc16.github.io/AbeilleDoc/Radio.html"><i class="fas fa-book"></i> ?</a> -->
-    </div>
-    <div class="col-sm-5">
-        <?php
-        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "Ext PAN ID").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
-            echo '<span id="idExtPanId">'.getCmdValueByName($eqId, 'Ext PAN ID').'</span>';
-        ?>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "Ext PAN ID")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[Ext PAN ID]");
-                    var element = document.getElementById('idExtPanId');
-                    element.textContent = _options.display_value;
-                }
-            </script>
-        </div>
-        <!-- TODO <input type="text" name="extendedPanId" placeholder="XXXXXXXX">
-        <button type="button" onclick="sendZigate('setExtPANId', '')">Modifier</button> -->
     </div>
 </div>
 
@@ -106,14 +76,8 @@
         <?php
         echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "Network Channel").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
             echo '<span id="idChannel" title="{{Canal actuel}}">'.getCmdValueByName($eqId, 'Network Channel').'</span>';
+            addJsUpdateFunction($eqId, 'Network-Channel', 'idChannel');
         ?>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "Network Channel")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[Network Channel]");
-                    var element = document.getElementById('idChannel');
-                    element.textContent = _options.display_value;
-                }
-            </script>
             <input type="text" id="idChannelMask" placeholder="ex: 07FFF800" title="{{Masque des canaux autorisés (en hexa, 1 bit par canal, 800=canal 11, 07FFF800=tous les canaux de 11 à 26)}}" style="margin-left:10px; width:100px">
             <a class="btn btn-warning" onclick="sendZigate('setChannelMask', '')">Modifier</a>
         </div>
@@ -128,14 +92,8 @@
         <?php
         echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "Inclusion Status").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
             echo '<span id="idInclusionMode">'.getCmdValueByName($eqId, 'Inclusion Status').'</span>';
+            addJsUpdateFunction($eqId, 'permitJoin-Status', 'idInclusionMode');
             ?>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "Inclusion Status")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[Inclusion Status]");
-                    var element = document.getElementById('idInclusionMode');
-                    element.textContent = _options.display_value;
-                }
-            </script>
         </div>
     </div>
 </div>
@@ -151,16 +109,40 @@
         ?>
             <a class="btn btn-warning" onclick="sendZigate('getTime', '')">Lire</a>
             <span id="idZgTime">- ? -</span>
-            <script>
-                <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "ZiGate-Time")."'] = function(_options){"; ?>
-                    console.log("jeedom.cmd.update[Zigate-Time]");
-                    var element = document.getElementById('idZgTime');
-                    element.textContent = _options.display_value;
-                }
-                // jeedom.cmd.update['233']({display_value:'#state#'});
-            </script>
+            <?php
+            addJsUpdateFunction($eqId, 'ZiGate-Time', 'idZgTime');
+            ?>
             <a class="btn btn-warning" onclick="sendZigate('setTime', '')">Mettre à l'heure</a>
         </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="col-sm-3 control-label">PAN ID</label>
+    <div class="col-sm-5">
+        <?php
+        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "PAN ID").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
+            echo '<span id="idPanId">'.getCmdValueByName($eqId, 'PAN ID').'</span>';
+            addJsUpdateFunction($eqId, 'PAN-ID', 'idPanId');
+        echo '</div>';
+        ?>
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="col-sm-3 control-label">
+        <label class="">Extended PAN ID</label>
+        <!-- <a class="btn btn-primary btn-xs" target="_blank" href="https://kiwihc16.github.io/AbeilleDoc/Radio.html"><i class="fas fa-book"></i> ?</a> -->
+    </div>
+    <div class="col-sm-5">
+        <?php
+        echo '<div class="cmd" data-type="info" data-subtype="string" data-cmd_id="'.getCmdIdByName($eqId, "Ext PAN ID").'" data-version="dashboard" data-eqlogic_id="'.$eqId.'">';
+            echo '<span id="idExtPanId">'.getCmdValueByName($eqId, 'Ext PAN ID').'</span>';
+            addJsUpdateFunction($eqId, 'Ext_PAN-ID', 'idExtPanId');
+        ?>
+        </div>
+        <!-- TODO <input type="text" name="extendedPanId" placeholder="XXXXXXXX">
+        <button type="button" onclick="sendZigate('setExtPANId', '')">Modifier</button> -->
     </div>
 </div>
 
@@ -171,15 +153,11 @@
     </div>
     <div class="col-sm-5">
         <a class="btn btn-warning" onclick="sendZigate('getTXPower', '')">Lire</a>
-        <span id="idZgPower">- ? -</span>
-        <script>
-            <?php echo "jeedom.cmd.update['".getCmdIdByName($eqId, "ZiGate-Power")."'] = function(_options){"; ?>
-                console.log("jeedom.cmd.update[ZiGate-Power]");
-                var element = document.getElementById('idZgPower');
-                element.textContent = _options.display_value;
-            }
-            // jeedom.cmd.update['233']({display_value:'#state#'});
-        </script>
+        <?php
+        $txPower = getCmdValueByLogicId($eqId, "ZiGate-Power"); // Getting initial value is important !
+        echo '<span id="idZgPower">'.$txPower.'</span>';
+        addJsUpdateFunction($eqId, 'ZiGate-Power', 'idZgPower');
+        ?>
         <!-- <a class="btn btn-warning" onclick="sendZigate('setTXPower', '')">Modifier</a> -->
     </div>
 </div>

--- a/desktop/php/AbeilleEq-Advanced.php
+++ b/desktop/php/AbeilleEq-Advanced.php
@@ -3,29 +3,113 @@
 
 <?php
     if ($dbgDeveloperMode) echo __FILE__;
+
+    function addDocButton($chapter) {
+        // $urlUserMan = "https://kiwihc16.github.io/AbeilleDoc"; // Constant defined in Abeille config
+        echo '<a class="btn btn-primary btn-xs" target="_blank" href="'.urlUserMan.'/'.$chapter.'"><i class="fas fa-book"></i> ?</a>';
+    }
+
+    /* Returns current cmd value identified by its Jeedom name */
+    function getCmdValueByName($eqId, $cmdName) {
+        $cmd = AbeilleCmd::byEqLogicIdCmdName($eqId, $cmdName);
+        if (!is_object($cmd))
+            return "";
+        return $cmd->execCmd();
+    }
+
+    /* Returns current cmd value identified by its Jeedom logical ID name */
+    function getCmdValueByLogicId($eqId, $logicId) {
+        $cmd = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, $logicId);
+        if (!is_object($cmd))
+            return "";
+        return $cmd->execCmd();
+    }
+
+    /* Returns cmd ID identified by its Jeedom name */
+    function getCmdIdByName($eqId, $cmdName) {
+        $cmd = AbeilleCmd::byEqLogicIdCmdName($eqId, $cmdName);
+        if (!is_object($cmd))
+            return "";
+        return $cmd->getId();
+    }
+
+    /* Returns cmd ID identified by its Jeedom logical ID name */
+    function getCmdIdByLogicId($eqId, $logicId) {
+        $cmd = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, $logicId);
+        if (!is_object($cmd))
+            return "";
+        return $cmd->getId();
+    }
+
+    function addEpButton($id, $defEp) {
+        echo '<input id="'.$id.'" title="{{End Point, format hexa (ex: 01)}}" value="'.$defEp.'"  style="width:30px; margin-left: 8px" />';
+    }
+
+    function addClusterButton($id) {
+        global $zbClusters;
+        echo '<select id="'.$id.'" title="{{Cluster}}" style="width:140px; margin-left: 8px">';
+        foreach ($zbClusters as $clustId => $clust) {
+            echo '<option value="'.$clustId.'">'.$clustId.' / '.$clust['name'].'</option>';
+        }
+        echo '</select>';
+    }
+
+    // Add direction input
+    function addDirInput($id) {
+        echo '<input id="'.$id.'" style="width:80px; margin-left: 8px" title="{{Direction. Format hex string 2 car (00=vers serveur, 01=vers client)}}" placeholder="{{Dir (ex: 00)}}" />';
+    }
+
+    // Add manufacturer ID input
+    function addManufIdInput($id) {
+        echo '<input id="'.$id.'" style="width:80px; margin-left: 8px" title="{{Manuf ID. Format hex string 4 car (par défaut=aucun)}}" placeholder="{{Manuf ID (ex: 115F)}}" />';
+    }
+
+    // Create drop down list of IEEE addresses, excluding zigate by default
+    function addIeeeListButton($id, $withZigate = false) {
+        echo '<select id="'.$id.'" title="{{Equipements}}" style="width:140px; margin-left: 8px">';
+        $eqLogics = eqLogic::byType('Abeille');
+        foreach ($eqLogics as $eqLogic) {
+            list($net, $addr) = explode( "/", $eqLogic->getLogicalId());
+            if (($addr == '0000') && !$withZigate)
+                continue; // Excluding zigates
+
+            $ieee = $eqLogic->getConfiguration('IEEE', '');
+            if ($ieee == '')
+                continue;
+            $eqName = $eqLogic->getName();
+            echo '<option value="'.$ieee.'">'.$ieee.' / '.$eqName.'</option>';
+        }
+        echo '</select>';
+    }
+
+    function addAttrInput($id) {
+        echo '<input id="'.$id.'" style="width:120px; margin-left: 8px" placeholder="{{Attrib (ex: 0021)}}" title="Attribut, format hex 4 caracteres (ex: 0508)"/>';
+    }
+
+    function addJsUpdateFunction($eqId, $cmdLogicId, $spanId) {
+        echo "<script>";
+        echo "jeedom.cmd.update['".getCmdIdByLogicId($eqId, $cmdLogicId)."'] = function(_options) {";
+            echo "console.log('jeedom.cmd.update[".$cmdLogicId."]');";
+            // console.log(_options);
+            echo "var element = document.getElementById('".$spanId."');";
+            echo "element.textContent = _options.display_value;";
+        echo "}";
+        echo "</script>";
+    }
 ?>
 
 <form class="form-horizontal">
-
     <?php
+        require_once __DIR__.'/../../core/php/AbeilleZigbeeConst.php';
+        include 'AbeilleEq-Advanced-Common.php';
 
-        if (1) {
-            require_once __DIR__.'/../../core/php/AbeilleZigbeeConst.php';
-            include 'AbeilleEq-Advanced-fct.php';
-            include 'AbeilleEq-Advanced-Common.php';
-
-                    // If eq is a zigate (short addr=0000), display special parameters
-            if ($eqAddr == "0000") {
-                include 'AbeilleEq-Advanced-Zigate.php';
-            }
-            else {
-                include 'AbeilleEq-Advanced-Device.php';
-                include 'AbeilleEq-Advanced-Specific.php';
-            }
-
-            include 'AbeilleEq-Advanced-Interrogations.php';
+        if ($eqAddr == "0000") { // Zigate
+            include 'AbeilleEq-Advanced-Zigate.php';
+        } else {
+            include 'AbeilleEq-Advanced-Device.php';
+            include 'AbeilleEq-Advanced-Specific.php';
         }
 
+        include 'AbeilleEq-Advanced-Interrogations.php';
     ?>
-
 </form>

--- a/desktop/php/AbeilleEq-Js.php
+++ b/desktop/php/AbeilleEq-Js.php
@@ -140,7 +140,7 @@
 
                             // Informing parser that some equipements have to be considered "phantom"
                             var xhr = new XMLHttpRequest();
-                            xhr.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueCtrlToParser+"&msg=type:eqRemoved_net:Abeille"+js_zgId+"_eqList:"+js_eqAddr, true);
+                            xhr.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueXToParser+"&msg=type:eqRemoved_net:Abeille"+js_zgId+"_eqList:"+js_eqAddr, true);
                             xhr.send();
                         }
                     });
@@ -546,7 +546,7 @@
         }
 
         var xhttp = new XMLHttpRequest();
-        xhttp.open("GET", "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueKeyXmlToCmd+"&topic="+topic+"&payload="+payload, false);
+        xhttp.open("GET", "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId="+js_queueXToCmd+"&topic="+topic+"&payload="+payload, false);
         xhttp.send();
 
         xhttp.onreadystatechange = function() {

--- a/desktop/php/AbeilleEq-Main-Generic.php
+++ b/desktop/php/AbeilleEq-Main-Generic.php
@@ -15,6 +15,20 @@
 </div>
 
 <div class="form-group">
+    <label class="col-sm-3 control-label">{{Type}}</label>
+    <div class="col-sm-3">
+        <?php
+            $eqModel = $eqLogic->getConfiguration('ab::eqModel', '');
+            if ($eqModel != '')
+                $type = $eqModel['type'];
+            else
+                $type = '';
+            echo '<input type="text" readonly style="width:100%" title="{{Type d\'équipement}}" value="'.$type.'" />';
+        ?>
+    </div>
+</div>
+
+<div class="form-group">
     <label class="col-sm-3 control-label">{{Objet parent}}</label>
     <div class="col-sm-3">
         <select class="eqLogicAttr form-control" data-l1key="object_id">

--- a/desktop/php/AbeilleEq.php
+++ b/desktop/php/AbeilleEq.php
@@ -39,11 +39,10 @@
     echo '<script>var js_eqAddr = "'.$eqAddr.'";</script>'; // PHP to JS
     echo '<script>var js_eqIeee = "'.$eqIeee.'";</script>'; // PHP to JS
     echo '<script>var js_zgId = '.$zgId.';</script>'; // PHP to JS
-    // echo '<script>var js_queueKeyXmlToCmd = '.queueKeyXmlToCmd.';</script>'; // PHP to JS
     echo '<script>var js_batteryType = "'.$batteryType.'";</script>'; // PHP to JS
     $abQueues = $GLOBALS['abQueues'];
-    echo '<script>var js_queueKeyXmlToCmd = '.$abQueues['xToCmd']['id'].';</script>'; // PHP to JS
-    echo '<script>var js_queueCtrlToParser = "'.$abQueues['ctrlToParser']['id'].'";</script>'; // PHP to JS
+    echo '<script>var js_queueXToCmd = '.$abQueues['xToCmd']['id'].';</script>'; // PHP to JS
+    echo '<script>var js_queueXToParser = "'.$abQueues['xToParser']['id'].'";</script>'; // PHP to JS
 ?>
 
 <!-- For all modals on 'Abeille' page. -->
@@ -68,7 +67,13 @@
 
         <!-- Displays Jeedom specifics  -->
         <div role="tabpanel" class="tab-pane active" id="idMain">
-            <?php include 'AbeilleEq-Main.php'; ?>
+            <form class="form-horizontal">
+                <?php
+                    include 'AbeilleEq-Main-Generic.php';
+                    include 'AbeilleEq-Main-Icon.php';
+                    include 'AbeilleEq-Main-Others.php';
+                ?>
+            </form>
         </div>
 
         <!-- Displays advanced & Zigbee specifics  -->

--- a/desktop/php/AbeilleEqAssist.php
+++ b/desktop/php/AbeilleEqAssist.php
@@ -50,7 +50,7 @@
     echo '<script>var js_jsonName = "'.$jsonName.'";</script>'; // PHP to JS
     echo '<script>var js_jsonLocation = "'.$jsonLocation.'";</script>'; // PHP to JS
     echo '<script>var js_queueXToCmd = "'.$abQueues['xToCmd']['id'].'";</script>'; // PHP to JS
-    echo '<script>var js_queueKeyCtrlToParser = "'.$abQueues['ctrlToParser']['id'].'";</script>'; // PHP to JS
+    echo '<script>var js_queueXToParser = "'.$abQueues['xToParser']['id'].'";</script>'; // PHP to JS
 
     $pluginDir = __DIR__."/../../"; // Plugin root dir
     echo '<script>let js_pluginDir = "'.$pluginDir.'";</script>';
@@ -845,6 +845,9 @@
         for (var epId in endPoints) {
             // console.log("EP "+epId);
             ep = endPoints[epId];
+
+            if (!isset(ep.servClusters))
+                continue;
 
             // Basic cluster
             if (isset(ep.servClusters["0000"]) && isset(ep.servClusters["0000"]['attributes'])) {
@@ -2033,7 +2036,7 @@ console.log(zEndPoints);
         openReturnChannel();
 
         var xhttp = new XMLHttpRequest();
-        xhttp.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?queueId="+js_queueKeyCtrlToParser+"&msg=type:sendToCli_net:Abeille"+js_zgNb+"_addr:"+js_eqAddr+"_ieee:"+js_eqIeee, true);
+        xhttp.open("GET", "plugins/Abeille/core/php/AbeilleCliToQueue.php?queueId="+js_queueXToParser+"&msg=type:sendToCli_net:Abeille"+js_zgNb+"_addr:"+js_eqAddr+"_ieee:"+js_eqIeee, true);
         xhttp.send();
 
         requestInfos('epList');

--- a/desktop/php/AbeilleFormAction.php
+++ b/desktop/php/AbeilleFormAction.php
@@ -8,7 +8,6 @@
 
     function sendMessageFromFormToCmd($topic, $payload) {
         global $abQueues;
-logDebug("LA=".$json_encode($abQueues));
         $queueId = $abQueues['xToCmd']['id']; // Previously formToCmd queue
         $queueKeyFormToCmd = msg_get_queue($queueId);
 
@@ -23,51 +22,51 @@ logDebug("LA=".$json_encode($abQueues));
         }
     }
 
-    function ApplySettingsToNE($item, $value) {
-        $deviceId = substr( $item, strpos($item,"-")+1 );
-        log::add('Abeille', 'debug', "deviceId: ".substr( $item, strpos($item,"-")+1 ) );
-        $device = Abeille::byId(substr( $item, strpos($item,"-")+1 ));
-        list( $dest, $address ) = explode( "/", $device->getLogicalId() );
-        log::add('Abeille', 'debug', "NE: ".$device->getName()." - dest: ".$dest." - address: ".$address );
-        // $EP = $device->getConfiguration('mainEP');
-        // log::add('Abeille', 'debug', 'EP: '.$EP );
+    // function ApplySettingsToNE($item, $value) {
+    //     $deviceId = substr( $item, strpos($item,"-")+1 );
+    //     log::add('Abeille', 'debug', "deviceId: ".substr( $item, strpos($item,"-")+1 ) );
+    //     $device = Abeille::byId(substr( $item, strpos($item,"-")+1 ));
+    //     list( $dest, $address ) = explode( "/", $device->getLogicalId() );
+    //     log::add('Abeille', 'debug', "NE: ".$device->getName()." - dest: ".$dest." - address: ".$address );
+    //     // $EP = $device->getConfiguration('mainEP');
+    //     // log::add('Abeille', 'debug', 'EP: '.$EP );
 
-        foreach ( $device->searchCmdByConfiguration('execAtCreation','action') as $cmd ) {
-            log::add('Abeille', 'debug', 'Cmd: '.$cmd->getName() );
-            if ($cmd->getConfiguration('execAtCreation','')=='Yes') {
-                if ($cmd->getConfiguration('execAtCreationDelay','0')>0) {
-                    log::add('Abeille', 'debug', '     Send Cmd: '.$cmd->getName() . ' - ' . $cmd->getConfiguration('topic','') . ' - ' . $cmd->getConfiguration('request','') );
-                    $topic = 'Tempo'.'Cmd'.$device->getLogicalId().'/'.$cmd->getConfiguration('topic','').'&time='.(time()+$cmd->getConfiguration('execAtCreationDelay','0'));
-                    $topic = AbeilleCmd::updateField($dest, $cmd, $topic);
-                    log::add('Abeille', 'debug', '     Send Cmd: topic: '.$topic );
-                    $request = $cmd->getConfiguration('request','');
-                    $request = AbeilleCmd::updateField($dest, $cmd, $request);
-                    log::add('Abeille', 'debug', '     Send Cmd: request: '.$request );
-                    sendMessageFromFormToCmd( $topic, $request );
-                    // $cmd->execute();
-                }
-            }
-        }
-    }
+    //     foreach ( $device->searchCmdByConfiguration('execAtCreation','action') as $cmd ) {
+    //         log::add('Abeille', 'debug', 'Cmd: '.$cmd->getName() );
+    //         if ($cmd->getConfiguration('execAtCreation','')=='Yes') {
+    //             if ($cmd->getConfiguration('execAtCreationDelay','0')>0) {
+    //                 log::add('Abeille', 'debug', '     Send Cmd: '.$cmd->getName() . ' - ' . $cmd->getConfiguration('topic','') . ' - ' . $cmd->getConfiguration('request','') );
+    //                 $topic = 'Tempo'.'Cmd'.$device->getLogicalId().'/'.$cmd->getConfiguration('topic','').'&time='.(time()+$cmd->getConfiguration('execAtCreationDelay','0'));
+    //                 $topic = AbeilleCmd::updateField($dest, $cmd, $topic);
+    //                 log::add('Abeille', 'debug', '     Send Cmd: topic: '.$topic );
+    //                 $request = $cmd->getConfiguration('request','');
+    //                 $request = AbeilleCmd::updateField($dest, $cmd, $request);
+    //                 log::add('Abeille', 'debug', '     Send Cmd: request: '.$request );
+    //                 sendMessageFromFormToCmd( $topic, $request );
+    //                 // $cmd->execute();
+    //             }
+    //         }
+    //     }
+    // }
 
-    function getInfosFromNe($item, $value) {
-        $deviceId = substr( $item, strpos($item,"-")+1 );
-        log::add('Abeille', 'debug', "deviceId: ".substr( $item, strpos($item,"-")+1 ) );
-        $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
-        list( $dest, $address ) = explode( "/", $device->getLogicalId() );
-        log::add('Abeille', 'debug', "dest: ".$dest." address: ".$address);
-        $EP = $device->getConfiguration('mainEP');
-        log::add('Abeille', 'debug', "mainEP: ".$EP);
+    // function getInfosFromNe($item, $value) {
+    //     $deviceId = substr( $item, strpos($item,"-")+1 );
+    //     log::add('Abeille', 'debug', "deviceId: ".substr( $item, strpos($item,"-")+1 ) );
+    //     $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
+    //     list( $dest, $address ) = explode( "/", $device->getLogicalId() );
+    //     log::add('Abeille', 'debug', "dest: ".$dest." address: ".$address);
+    //     $EP = $device->getConfiguration('mainEP');
+    //     log::add('Abeille', 'debug', "mainEP: ".$EP);
 
-        // Get Name
-        sendMessageFromFormToCmd('Cmd'.$dest.'/0000/ActiveEndPoint',           'address='.$address                             );
-        sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getSimpleDescriptor', 'ep='.$EP);
-        sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getIeeeAddress', '');
-        sendMessageFromFormToCmd('Cmd'.$dest.'/0000/getName',                  'address='.$address.'&destinationEndPoint='.$EP );
-        sendMessageFromFormToCmd('Cmd'.$dest.'/0000/getLocation',              'address='.$address.'&destinationEndPoint='.$EP );
-        sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getGroupMembership', 'ep='.$EP );
-        // sendMessageFromFormToCmd('CmdAbeille/0000/getSceneMembership',   'address='.$address.'&DestinationEndPoint='.$EP.'&groupID='.$grouID, 0);
-    }
+    //     // Get Name
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/0000/ActiveEndPoint',           'address='.$address                             );
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getSimpleDescriptor', 'ep='.$EP);
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getIeeeAddress', '');
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/0000/getName',                  'address='.$address.'&destinationEndPoint='.$EP );
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/0000/getLocation',              'address='.$address.'&destinationEndPoint='.$EP );
+    //     sendMessageFromFormToCmd('Cmd'.$dest.'/'.$address.'/getGroupMembership', 'ep='.$EP );
+    //     // sendMessageFromFormToCmd('CmdAbeille/0000/getSceneMembership',   'address='.$address.'&DestinationEndPoint='.$EP.'&groupID='.$grouID, 0);
+    // }
 
     try {
 
@@ -266,50 +265,50 @@ logDebug("LA=".$json_encode($abQueues));
                 break;
 
             // Template
-            case 'Apply Template':
-                foreach ( $_POST as $item=>$Value ) {
-                    if ( strpos("-".$item, "eqSelected") == 1 ) {
-                        $deviceId = substr( $item, strpos($item,"-")+1 );
-                        // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
-                        // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
-                        // $address = substr($device->getLogicalId(),8);
-                        // $EP = $device->getConfiguration('mainEP');
-                        // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
-                        abeille::updateConfigAbeille( $deviceId );
-                        // abeille::updateConfigAbeille( );
-                    }
-                }
-                break;
+            // case 'Apply Template':
+            //     foreach ( $_POST as $item=>$Value ) {
+            //         if ( strpos("-".$item, "eqSelected") == 1 ) {
+            //             $deviceId = substr( $item, strpos($item,"-")+1 );
+            //             // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
+            //             // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
+            //             // $address = substr($device->getLogicalId(),8);
+            //             // $EP = $device->getConfiguration('mainEP');
+            //             // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
+            //             abeille::updateConfigAbeille( $deviceId );
+            //             // abeille::updateConfigAbeille( );
+            //         }
+            //     }
+            //     break;
 
-            case 'Get Infos from NE':
-                foreach ( $_POST as $item=>$Value ) {
-                    if ( strpos("-".$item, "eqSelected") == 1 ) {
-                        // $deviceId = substr( $item, strpos($item,"-")+1 );
-                        // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
-                        // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
-                        // $address = substr($device->getLogicalId(),8);
-                        // $EP = $device->getConfiguration('mainEP');
-                        // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
-                        getInfosFromNe($item, $Value);
-                        // abeille::updateConfigAbeille( );
-                    }
-                }
-                break;
+            // case 'Get Infos from NE':
+            //     foreach ( $_POST as $item=>$Value ) {
+            //         if ( strpos("-".$item, "eqSelected") == 1 ) {
+            //             // $deviceId = substr( $item, strpos($item,"-")+1 );
+            //             // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
+            //             // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
+            //             // $address = substr($device->getLogicalId(),8);
+            //             // $EP = $device->getConfiguration('mainEP');
+            //             // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
+            //             getInfosFromNe($item, $Value);
+            //             // abeille::updateConfigAbeille( );
+            //         }
+            //     }
+            //     break;
 
-            case 'Apply Settings to NE':
-                foreach ( $_POST as $item=>$Value ) {
-                    if ( strpos("-".$item, "eqSelected") == 1 ) {
-                        // $deviceId = substr( $item, strpos($item,"-")+1 );
-                        // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
-                        // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
-                        // $address = substr($device->getLogicalId(),8);
-                        // $EP = $device->getConfiguration('mainEP');
-                        // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
-                        ApplySettingsToNE($item, $Value);
-                        // abeille::updateConfigAbeille( );
-                    }
-                }
-                break;
+            // case 'Apply Settings to NE':
+            //     foreach ( $_POST as $item=>$Value ) {
+            //         if ( strpos("-".$item, "eqSelected") == 1 ) {
+            //             // $deviceId = substr( $item, strpos($item,"-")+1 );
+            //             // echo "Id: ".substr( $item, strpos($item,"-")+1 )."<br>";
+            //             // $device = eqLogic::byId(substr( $item, strpos($item,"-")+1 ));
+            //             // $address = substr($device->getLogicalId(),8);
+            //             // $EP = $device->getConfiguration('mainEP');
+            //             // sendMessageFromFormToCmd('CmdAbeille/0000/addGroup', 'address='.(substr( $item, strpos($item,"-")+1 )).'&DestinationEndPoint='.$EP.'&groupAddress='.$_POST['group'] );
+            //             ApplySettingsToNE($item, $Value);
+            //             // abeille::updateConfigAbeille( );
+            //         }
+            //     }
+            //     break;
 
             // case "Remplace":
             //     log::add('Abeille', 'debug', 'Replace: '.$_POST['ghost'] . ' - ' . $_POST['real']);

--- a/docs/fr_FR/Changelog.rst
+++ b/docs/fr_FR/Changelog.rst
@@ -1,6 +1,25 @@
 ChangeLog
 =========
 
+- Interne: Version DB, date = 20220407.
+- Analyse/santé: Correction affichage ports utilisés.
+- Interne: Nettoyage fonctions obsolètes.
+- Interne: Suppression de plusieurs commandes obsolètes (dispos sur page avancée) 'Ruche':
+
+  - 'replaceEquipement'
+  - 'Get Time'
+  - 'SystemMessage' (provoque mise à jour erronnée date de communication Zigate)
+- Interne: Page EQ/avancé. Qq optimisations.
+- Interne: Mise-à-jour controle/redémarrage des démons.
+- Zigate v2/apparition équipements inconnus: Ajout verrue (2368).
+- Interne: Plus qu'une seule queue d'entrée au parser.
+- Interne: Tuya: Support préliminaire TV02.
+- Interne: Grosse mise-à-jour pour meilleur support des équipements Tuya.
+- Philips LOM007 smart plug: Ajout support (2374).
+- JSON commandes: 'forceReturnLineAfter/Before' is obsolete. Replaced by 'nextLine' = 'after/before'.
+- Interne: Sauvegarde des infos du modele dans la DB eqLogic => 'ab::eqModel'.
+- Page EQ: Ajout affichage type d'équipement.
+
 220407-BETA-1
 -------------
 

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -186,7 +186,7 @@
             config::save('DbVersion', '20201025', 'Abeille');
         }
 
-        /* Version 20201122 changes:
+        /* Version 20220407 changes:
            - Config DB: blocageTraitementAnnonce defaulted to "Non"
            - Config DB: agressifTraitementAnnonce defaulted to 4
            - Rename all eq names that use short addr to use Jeedom ID instead.
@@ -205,7 +205,7 @@
            - Cmd DB: Correcting wrong attribute size for 'getPlugVAW' (attrId=0505,508,050B)
            - Eq DB: Removing obsolete 'lastCommunicationTimeOut', 'type'.
          */
-        if (intval($dbVersion) < 20201122) {
+        if (intval($dbVersion) < 20220407) {
             if (config::byKey('blocageTraitementAnnonce', 'Abeille', 'none', 1) == "none") {
                 config::save('blocageTraitementAnnonce', 'Non', 'Abeille');
             }
@@ -398,7 +398,7 @@
                 log::add('Abeille', 'debug', '  Zigate '.$zgId.": Updated 'AbeilleSerialPort".$zgId."'");
             }
 
-            //    config::save('DbVersion', '20201122', 'Abeille');
+               config::save('DbVersion', '20220407', 'Abeille');
         }
     }
 


### PR DESCRIPTION
- Interne: Version DB, date = 20220407.
- Analyse/santé: Correction affichage ports utilisés.
- Interne: Nettoyage fonctions obsolètes.
- Interne: Suppression de plusieurs commandes obsolètes (dispos sur page avancée) 'Ruche':

  - 'replaceEquipement'
  - 'Get Time'
  - 'SystemMessage' (provoque mise à jour erronnée date de communication Zigate)
- Interne: Page EQ/avancé. Qq optimisations.
- Interne: Mise-à-jour controle/redémarrage des démons.
- Zigate v2/apparition équipements inconnus: Ajout verrue (2368).
- Interne: Plus qu'une seule queue d'entrée au parser.
- Interne: Tuya: Support préliminaire TV02.
- Interne: Grosse mise-à-jour pour meilleur support des équipements Tuya.
- Philips LOM007 smart plug: Ajout support (2374).
- JSON commandes: 'forceReturnLineAfter/Before' is obsolete. Replaced by 'nextLine' = 'after/before'.
- Interne: Sauvegarde des infos du modele dans la DB eqLogic => 'ab::eqModel'.
- Page EQ: Ajout affichage type d'équipement.
