### PR TITLE
Enhancements

### DIFF
--- a/.tools/update_json.php
+++ b/.tools/update_json.php
@@ -152,6 +152,36 @@
                     echo "  Cmd '".$cmdFName."' UPDATED.\n";
                 }
 
+                // Cluster 0003/Identify updates
+                else if (($cmdFName == "Identify") && $oldSyntax) {
+                    $cmdArr = Array(
+                        "use" => "Identify",
+                        // "params" => "ep=03",
+                        // "subType" => "numeric",
+                        // "template" => "door",
+                        // "genericType" => "OPENING",
+                        "isVisible" => 1
+                    );
+                    $commands2["Identify"] = $cmdArr;
+                    $devUpdated = true;
+                    echo "  Cmd '".$cmdFName."' UPDATED.\n";
+                }
+
+                // Cluster 0004/Groups updates
+                else if (($cmdFName == "Group-Membership") && $oldSyntax) {
+                    $cmdArr = Array(
+                        "use" => "Group-Membership",
+                        // "params" => "ep=03",
+                        // "subType" => "numeric",
+                        // "template" => "door",
+                        // "genericType" => "OPENING",
+                        "isVisible" => 1
+                    );
+                    $commands2["Groups"] = $cmdArr;
+                    $devUpdated = true;
+                    echo "  Cmd '".$cmdFName."' UPDATED.\n";
+                }
+
                 // Cluster 0006 updates
                 else if (($cmdFName == "etat") && $oldSyntax) {
                     $cmdArr = Array(

--- a/core/class/AbeilleCmd.class.php
+++ b/core/class/AbeilleCmd.class.php
@@ -151,8 +151,8 @@
                 $msgJson = json_encode($msg);
 
                 if (strpos($topic, "CmdCreate") === 0) {
-                    $queueAbeilleToAbeille = msg_get_queue($abQueues["abeilleToAbeille"]["id"]);
-                    if (msg_send($queueAbeilleToAbeille, 1, $msgJson, false, false)) {
+                    $queueXToAbeille = msg_get_queue($abQueues["xToAbeille"]["id"]);
+                    if (msg_send($queueXToAbeille, 1, $msgJson, false, false)) {
                         logMessage('debug', '-- execute(): CmdCreate: Msg sent: '.$msgJson);
                     } else {
                         logMessage('debug', '-- execute(): ERROR: CmdCreate: Could not send Msg');

--- a/core/class/AbeilleCmdProcess.class.php
+++ b/core/class/AbeilleCmdProcess.class.php
@@ -4321,7 +4321,7 @@
                         return;
                     }
 
-                    $transId = "23"; // Transaction ID ?
+                    $transId = tuyaGetTransId(); // Transaction ID
                     $dpId = $dp['id'];
                     $dpType = $dp['type'];
                     $dpData = $dp['data'];

--- a/core/class/AbeilleCmdQueue.class.php
+++ b/core/class/AbeilleCmdQueue.class.php
@@ -233,7 +233,7 @@
 
         public function msgToAbeille($topic, $payload) {
             global $abQueues;
-            $queueId = $abQueues['cmdToAbeille']['id'];
+            $queueId = $abQueues['xToAbeille']['id'];
             $queue = msg_get_queue($queueId);
 
             $msg = array();

--- a/core/class/AbeilleParser.class.php
+++ b/core/class/AbeilleParser.class.php
@@ -120,8 +120,6 @@
             $GLOBALS['requestedlevel'] = $this->requestedlevel ;
 
             $abQueues = $GLOBALS['abQueues'];
-            // $this->queueParserToAbeille     = msg_get_queue($abQueues["parserToAbeille"]["id"]);
-            // $this->queueParserToAbeille2    = msg_get_queue($abQueues["parserToAbeille2"]["id"]);
             $this->queueXToCmd          = msg_get_queue($abQueues["xToCmd"]["id"]);
             $this->queueParserToCmdAck  = msg_get_queue($abQueues["parserToCmdAck"]["id"]);
             $this->queueParserToLQI     = msg_get_queue($abQueues["parserToLQI"]["id"]);

--- a/core/class/AbeilleTools.class.php
+++ b/core/class/AbeilleTools.class.php
@@ -1193,7 +1193,7 @@ log::add('Abeille', 'debug', '  running='.json_encode($running));
             $messageToSend = ($message == "") ? "" : "$daemonName: $message";
             // log::add('Abeille', 'debug', "Process Monitoring: " .__CLASS__.':'.__FUNCTION__.':'.__LINE__.' sending '.$messageToSend.' to zigate '.$zigateNbr);
             if ( strlen($messageToSend) > 2 ) {
-            Abeille::publishMosquitto($abQueues["abeilleToAbeille"]["id"], PRIO_NORM,
+            Abeille::publishMosquitto($abQueues["xToAbeille"]["id"], PRIO_NORM,
                 "Abeille$zigateNbr/0000/SystemMessage", $messageToSend);
             }
         }

--- a/core/config/Abeille.config.php
+++ b/core/config/Abeille.config.php
@@ -15,19 +15,15 @@
     $abQueues["ctrlToCmd"] = array( "id" => 0x338, "max" => 2048 ); // Ctrl messages for AbeilleCmd
     $abQueues["parserToLQI"] = array( "id" => 0xE1, "max" => 2048 );
     $abQueues["parserToCli"] = array( "id" => 0x2D4, "max" => 1024 );
-    // $abQueues["parserToCmd"] = array( "id" => 0x3E6, "max" => 512 );
     $abQueues["parserToCmdAck"] = array( "id" => 0x3E7, "max" => 512 ); // Parser to cmd for 8000/8012/8702 statuses
-    $abQueues["parserToAbeille"] = array( "id" => 221, "max" => 512 ); // Parser Abeille, old path
-    $abQueues["parserToAbeille2"] = array( "id" => 222, "max" => 512 ); // Parser Abeille, new path
+    // $abQueues["parserToAbeille2"] = array( "id" => 222, "max" => 512 ); // Parser Abeille, new path
     $abQueues["xToCmd"] = array( "id" => 1212, "max" => 512 ); // AbeilleCmd inputs
     $abQueues["cmdToMon"] = array( "id" => 130, "max" => 512 ); // Messages to zigate (cmd to monitor)
     $abQueues["parserToMon"] = array( "id" => 131, "max" => 512 ); // Messages from zigate (parser to monitor)
     $abQueues["monToCmd"] = array( "id" => 132, "max" => 512 ); // Messages to cmd (addr update)
     $abQueues["parserToAssist"] = array( "id" => 141, "max" => 512 ); // Parser to EQ assistant
     $abQueues["assistToCmd"] = array( "id" => 142, "max" => 512 ); // Assistant to cmd
-    $abQueues["abeilleToAbeille"] = array( "id" => 121, "max" => 512 ); // ?
-    $abQueues["xmlToAbeille"] = array( "id" => 621, "max" => 512 ); // ?
-    $abQueues["cmdToAbeille"] = array( "id" => 321, "max" => 512 ); // ?
+    $abQueues["xToAbeille"] = array( "id" => 621, "max" => 512 ); // ?
     $GLOBALS['abQueues'] = $abQueues;
 
     // Tcharp38 note: WARNING: TOP PRIORITY is 1, not 5

--- a/core/config/devices/4090330P9_01/4090330P9_01.json
+++ b/core/config/devices/4090330P9_01/4090330P9_01.json
@@ -72,8 +72,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/4090330P9_02/4090330P9_02.json
+++ b/core/config/devices/4090330P9_02/4090330P9_02.json
@@ -72,8 +72,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/A60TWZ3/A60TWZ3.json
+++ b/core/config/devices/A60TWZ3/A60TWZ3.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/BSO/BSO.json
+++ b/core/config/devices/BSO/BSO.json
@@ -34,8 +34,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/CLA60RGBWOSRAM/CLA60RGBWOSRAM.json
+++ b/core/config/devices/CLA60RGBWOSRAM/CLA60RGBWOSRAM.json
@@ -72,8 +72,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/CLA60TWOSRAM/CLA60TWOSRAM.json
+++ b/core/config/devices/CLA60TWOSRAM/CLA60TWOSRAM.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/Cableoutlet_Legrand/Cableoutlet_Legrand.json
+++ b/core/config/devices/Cableoutlet_Legrand/Cableoutlet_Legrand.json
@@ -17,8 +17,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0000&attrId=4000"
             },
-            "include25": "Group-Membership",
-            "include24": "Identify",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1
@@ -28,7 +34,8 @@
                 "isVisible": 1
             },
             "Off": {
-                "use": "zbCmd-0006-Off",
+                "use": "cmdG-LegrandFC41",
+                "params": "Mode=05",
                 "isVisible": 1
             },
             "Get-Status": {
@@ -97,11 +104,6 @@
             "Frost protection": {
                 "use": "cmdG-LegrandFC41",
                 "params": "Mode=04",
-                "isVisible": 1
-            },
-            "Off": {
-                "use": "cmdG-LegrandFC41",
-                "params": "Mode=05",
                 "isVisible": 1
             }
         }

--- a/core/config/devices/ClassicA60RGBW/ClassicA60RGBW.json
+++ b/core/config/devices/ClassicA60RGBW/ClassicA60RGBW.json
@@ -26,8 +26,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ClassicA60Wclear-LIGHTIFY-2/ClassicA60Wclear-LIGHTIFY-2.json
+++ b/core/config/devices/ClassicA60Wclear-LIGHTIFY-2/ClassicA60Wclear-LIGHTIFY-2.json
@@ -31,8 +31,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ClassicA60Wclear-LIGHTIFY/ClassicA60Wclear-LIGHTIFY.json
+++ b/core/config/devices/ClassicA60Wclear-LIGHTIFY/ClassicA60Wclear-LIGHTIFY.json
@@ -30,8 +30,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ClassicB40TW-LIGHTIFY/ClassicB40TW-LIGHTIFY.json
+++ b/core/config/devices/ClassicB40TW-LIGHTIFY/ClassicB40TW-LIGHTIFY.json
@@ -37,8 +37,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/Connectedoutlet/Connectedoutlet.json
+++ b/core/config/devices/Connectedoutlet/Connectedoutlet.json
@@ -25,8 +25,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/Dimmerswitchwoneutral/Dimmerswitchwoneutral.json
+++ b/core/config/devices/Dimmerswitchwoneutral/Dimmerswitchwoneutral.json
@@ -46,8 +46,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/FLOALTpanelWS30x30/FLOALTpanelWS30x30.json
+++ b/core/config/devices/FLOALTpanelWS30x30/FLOALTpanelWS30x30.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/FLOALTpanelWS60x60/FLOALTpanelWS60x60.json
+++ b/core/config/devices/FLOALTpanelWS60x60/FLOALTpanelWS60x60.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/FYRTURblock-outrollerblind/FYRTURblock-outrollerblind.json
+++ b/core/config/devices/FYRTURblock-outrollerblind/FYRTURblock-outrollerblind.json
@@ -20,7 +20,10 @@
             "Stop": {
                 "use": "zbCmd-0102-Stop"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "WindowsCoveringLevel",
             "include25 2 2": "WindowsCoveringGetLevel",
             "include25 2 2 2": "WindowsCoveringGoToLevel",

--- a/core/config/devices/FlexRGBW/FlexRGBW.json
+++ b/core/config/devices/FlexRGBW/FlexRGBW.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/GL-B-001Z/GL-B-001Z.json
+++ b/core/config/devices/GL-B-001Z/GL-B-001Z.json
@@ -92,8 +92,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-B-008Z/GL-B-008Z.json
+++ b/core/config/devices/GL-B-008Z/GL-B-008Z.json
@@ -92,8 +92,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-C-006/GL-C-006.json
+++ b/core/config/devices/GL-C-006/GL-C-006.json
@@ -63,8 +63,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-C-007/GL-C-007.json
+++ b/core/config/devices/GL-C-007/GL-C-007.json
@@ -13,8 +13,14 @@
         },
         "type": "GLEDOPTO RGT+CCT LED Controller",
         "commands": {
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "On": {
                 "use": "zbCmd-0006-On",

--- a/core/config/devices/GL-C-008/GL-C-008.json
+++ b/core/config/devices/GL-C-008/GL-C-008.json
@@ -92,8 +92,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-G-001ZS/GL-G-001ZS.json
+++ b/core/config/devices/GL-G-001ZS/GL-G-001ZS.json
@@ -92,8 +92,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-MC-001/GL-MC-001.json
+++ b/core/config/devices/GL-MC-001/GL-MC-001.json
@@ -92,8 +92,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-S-003Z/GL-S-003Z.json
+++ b/core/config/devices/GL-S-003Z/GL-S-003Z.json
@@ -75,8 +75,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GL-S-004Z/GL-S-004Z.json
+++ b/core/config/devices/GL-S-004Z/GL-S-004Z.json
@@ -55,8 +55,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/GLEDOPTO/GLEDOPTO.json
+++ b/core/config/devices/GLEDOPTO/GLEDOPTO.json
@@ -39,9 +39,15 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "include26": "setLevel",
-            "include27": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include27 2": "Scene-Membership",
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"

--- a/core/config/devices/GUNNARPpanelround/GUNNARPpanelround.json
+++ b/core/config/devices/GUNNARPpanelround/GUNNARPpanelround.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/GardenspotRGB/GardenspotRGB.json
+++ b/core/config/devices/GardenspotRGB/GardenspotRGB.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/KADRILJrollerblind/KADRILJrollerblind.json
+++ b/core/config/devices/KADRILJrollerblind/KADRILJrollerblind.json
@@ -20,7 +20,10 @@
             "Stop": {
                 "use": "zbCmd-0102-Stop"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/Keyfob-ZB3.0/Keyfob-ZB3.0.json
+++ b/core/config/devices/Keyfob-ZB3.0/Keyfob-ZB3.0.json
@@ -11,7 +11,10 @@
         },
         "type": "NEO  Inmax 07046L Keyfob-ZB3.0",
         "commands": {
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/KiwiHC16_Test_01/KiwiHC16_Test_01.json
+++ b/core/config/devices/KiwiHC16_Test_01/KiwiHC16_Test_01.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LCA001/LCA001.json
+++ b/core/config/devices/LCA001/LCA001.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LCE002/LCE002.json
+++ b/core/config/devices/LCE002/LCE002.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LCT001/LCT001.json
+++ b/core/config/devices/LCT001/LCT001.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LCT010/LCT010.json
+++ b/core/config/devices/LCT010/LCT010.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LCT015/LCT015.json
+++ b/core/config/devices/LCT015/LCT015.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LIGHTIFYIndoorFlexRGBW/LIGHTIFYIndoorFlexRGBW.json
+++ b/core/config/devices/LIGHTIFYIndoorFlexRGBW/LIGHTIFYIndoorFlexRGBW.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LIGHTIFYOutdoorFlexRGBW/LIGHTIFYOutdoorFlexRGBW.json
+++ b/core/config/devices/LIGHTIFYOutdoorFlexRGBW/LIGHTIFYOutdoorFlexRGBW.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LLC011/LLC011.json
+++ b/core/config/devices/LLC011/LLC011.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LLC020/LLC020.json
+++ b/core/config/devices/LLC020/LLC020.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LST001/LST001.json
+++ b/core/config/devices/LST001/LST001.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LST002/LST002.json
+++ b/core/config/devices/LST002/LST002.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LTA001/LTA001.json
+++ b/core/config/devices/LTA001/LTA001.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LTW001/LTW001.json
+++ b/core/config/devices/LTW001/LTW001.json
@@ -56,8 +56,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LTW010/LTW010.json
+++ b/core/config/devices/LTW010/LTW010.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LTW012/LTW012.json
+++ b/core/config/devices/LTW012/LTW012.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LTW013/LTW013.json
+++ b/core/config/devices/LTW013/LTW013.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWA001/LWA001.json
+++ b/core/config/devices/LWA001/LWA001.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWA004/LWA004.json
+++ b/core/config/devices/LWA004/LWA004.json
@@ -13,8 +13,14 @@
         },
         "type": "Hue E27 single filament A60 bulb",
         "commands": {
-            "include0003-1": "Identify",
-            "include0004-1": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1

--- a/core/config/devices/LWA009/LWA009.json
+++ b/core/config/devices/LWA009/LWA009.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWB004/LWB004.json
+++ b/core/config/devices/LWB004/LWB004.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWB006/LWB006.json
+++ b/core/config/devices/LWB006/LWB006.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWB010/LWB010.json
+++ b/core/config/devices/LWB010/LWB010.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LWO001/LWO001.json
+++ b/core/config/devices/LWO001/LWO001.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/LXX60-CS27LX1.0/LXX60-CS27LX1.0.json
+++ b/core/config/devices/LXX60-CS27LX1.0/LXX60-CS27LX1.0.json
@@ -12,8 +12,14 @@
         },
         "type": "Zemismart ZW-EC-01 curtain switch",
         "commands": {
-            "include0003-1": "Identify",
-            "include0004-1": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1

--- a/core/config/devices/MOT-C1Z06C/MOT-C1Z06C.json
+++ b/core/config/devices/MOT-C1Z06C/MOT-C1Z06C.json
@@ -16,8 +16,14 @@
         "type": "Profalux volet gen 2",
         "commands": {
             "include4": "zb-0000-ZCLVersion",
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/MR16TWOSRAM/MR16TWOSRAM.json
+++ b/core/config/devices/MR16TWOSRAM/MR16TWOSRAM.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/Micromoduleswitch/Micromoduleswitch.json
+++ b/core/config/devices/Micromoduleswitch/Micromoduleswitch.json
@@ -26,8 +26,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/PAR1650TW/PAR1650TW.json
+++ b/core/config/devices/PAR1650TW/PAR1650TW.json
@@ -75,8 +75,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/PAR16RGBWZ3/PAR16RGBWZ3.json
+++ b/core/config/devices/PAR16RGBWZ3/PAR16RGBWZ3.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/PRZ/PRZ.json
+++ b/core/config/devices/PRZ/PRZ.json
@@ -27,8 +27,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/PSE03-v1.1.0/PSE03-v1.1.0.json
+++ b/core/config/devices/PSE03-v1.1.0/PSE03-v1.1.0.json
@@ -11,8 +11,14 @@
         "type": "Alarm PSE03-v1.1.0",
         "commands": {
             "include4": "zb-0000-ZCLVersion",
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/Plug01/Plug01.json
+++ b/core/config/devices/Plug01/Plug01.json
@@ -26,8 +26,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/PlugZ3/PlugZ3.json
+++ b/core/config/devices/PlugZ3/PlugZ3.json
@@ -28,7 +28,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/RB175W/RB175W.json
+++ b/core/config/devices/RB175W/RB175W.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/RF263/RF263.json
+++ b/core/config/devices/RF263/RF263.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/RF265/RF265.json
+++ b/core/config/devices/RF265/RF265.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/SM309/SM309.json
+++ b/core/config/devices/SM309/SM309.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/SPLZB-132/SPLZB-132.json
+++ b/core/config/devices/SPLZB-132/SPLZB-132.json
@@ -13,7 +13,10 @@
         },
         "type": "Frient Smart Plug Mini Type E (French)",
         "commands": {
-            "include0004-1": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "On": {
                 "use": "zbCmd-0006-On",
                 "isVisible": 1
@@ -62,7 +65,9 @@
                 "isVisible": 1,
                 "params": "mult=1&div=1"
             },
-            "Poll 0B04": { "use": "poll-0B04-0505-0508-050B" }
+            "Poll 0B04": {
+                "use": "poll-0B04-0505-0508-050B"
+            }
         }
     }
 }

--- a/core/config/devices/SPZB0001/SPZB0001.json
+++ b/core/config/devices/SPZB0001/SPZB0001.json
@@ -11,7 +11,10 @@
         },
         "type": "Eurotronic Spirit",
         "commands": {
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "include25 2 2 2": "spiritTemperatureConsigne",
             "include25 2 2": "spiritTemperatureConsigneGet",
             "include25 2": "spiritTemperatureConsigneSet",

--- a/core/config/devices/Shutterswitchwithneutral/Shutterswitchwithneutral.json
+++ b/core/config/devices/Shutterswitchwithneutral/Shutterswitchwithneutral.json
@@ -30,8 +30,14 @@
                 "use": "zbCmd-0102-Stop"
             },
             "include20": "getcurrent_position_lift_percentage",
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind 0102-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0102",

--- a/core/config/devices/TI0001/TI0001.json
+++ b/core/config/devices/TI0001/TI0001.json
@@ -10,7 +10,10 @@
         },
         "type": "Livolo Switch TI0001",
         "commands": {
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "include24 2 2 2 2 2": "setLivoloOff2",
             "include24 2 2 2 2 2 3": "setLivoloOff",
             "include24 2 2 2 2 2 2": "setLivoloOn2",

--- a/core/config/devices/TRADFRIDriver10W/TRADFRIDriver10W.json
+++ b/core/config/devices/TRADFRIDriver10W/TRADFRIDriver10W.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIDriver30W/TRADFRIDriver30W.json
+++ b/core/config/devices/TRADFRIDriver30W/TRADFRIDriver30W.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE14CWSopal600lm/TRADFRIbulbE14CWSopal600lm.json
+++ b/core/config/devices/TRADFRIbulbE14CWSopal600lm/TRADFRIbulbE14CWSopal600lm.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE14WS470lm/TRADFRIbulbE14WS470lm.json
+++ b/core/config/devices/TRADFRIbulbE14WS470lm/TRADFRIbulbE14WS470lm.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE14WSopal400lm/TRADFRIbulbE14WSopal400lm.json
+++ b/core/config/devices/TRADFRIbulbE14WSopal400lm/TRADFRIbulbE14WSopal400lm.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/TRADFRIbulbE14WSopal600lm/TRADFRIbulbE14WSopal600lm.json
+++ b/core/config/devices/TRADFRIbulbE14WSopal600lm/TRADFRIbulbE14WSopal600lm.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE14Wopch400lm/TRADFRIbulbE14Wopch400lm.json
+++ b/core/config/devices/TRADFRIbulbE14Wopch400lm/TRADFRIbulbE14Wopch400lm.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE26WSclear950lm/TRADFRIbulbE26WSclear950lm.json
+++ b/core/config/devices/TRADFRIbulbE26WSclear950lm/TRADFRIbulbE26WSclear950lm.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27CWSopal600lm/TRADFRIbulbE27CWSopal600lm.json
+++ b/core/config/devices/TRADFRIbulbE27CWSopal600lm/TRADFRIbulbE27CWSopal600lm.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WSclear806lm/TRADFRIbulbE27WSclear806lm.json
+++ b/core/config/devices/TRADFRIbulbE27WSclear806lm/TRADFRIbulbE27WSclear806lm.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WSclear950lm/TRADFRIbulbE27WSclear950lm.json
+++ b/core/config/devices/TRADFRIbulbE27WSclear950lm/TRADFRIbulbE27WSclear950lm.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WSopal1000lm/TRADFRIbulbE27WSopal1000lm.json
+++ b/core/config/devices/TRADFRIbulbE27WSopal1000lm/TRADFRIbulbE27WSopal1000lm.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WSopal980lm/TRADFRIbulbE27WSopal980lm.json
+++ b/core/config/devices/TRADFRIbulbE27WSopal980lm/TRADFRIbulbE27WSopal980lm.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WW806lm/TRADFRIbulbE27WW806lm.json
+++ b/core/config/devices/TRADFRIbulbE27WW806lm/TRADFRIbulbE27WW806lm.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27WWclear250lm/TRADFRIbulbE27WWclear250lm.json
+++ b/core/config/devices/TRADFRIbulbE27WWclear250lm/TRADFRIbulbE27WWclear250lm.json
@@ -27,7 +27,10 @@
                 "isVisible": 1
             },
             "include11": "setLevel",
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "Get-Status": {
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
@@ -36,7 +39,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27Wopal1000lm/TRADFRIbulbE27Wopal1000lm.json
+++ b/core/config/devices/TRADFRIbulbE27Wopal1000lm/TRADFRIbulbE27Wopal1000lm.json
@@ -29,7 +29,10 @@
                 "isVisible": 1
             },
             "include11": "setLevel",
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "Get-Status": {
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
@@ -38,7 +41,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbE27Wopal1000lm2/TRADFRIbulbE27Wopal1000lm2.json
+++ b/core/config/devices/TRADFRIbulbE27Wopal1000lm2/TRADFRIbulbE27Wopal1000lm2.json
@@ -20,7 +20,10 @@
                 "use": "zb-0008-CurrentLevel",
                 "isVisible": 1
             },
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "include11": "setLevel",
             "On": {
                 "use": "zbCmd-0006-On",

--- a/core/config/devices/TRADFRIbulbE27opal1000lm/TRADFRIbulbE27opal1000lm.json
+++ b/core/config/devices/TRADFRIbulbE27opal1000lm/TRADFRIbulbE27opal1000lm.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbGU10W400lm/TRADFRIbulbGU10W400lm.json
+++ b/core/config/devices/TRADFRIbulbGU10W400lm/TRADFRIbulbGU10W400lm.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbGU10WS400lm/TRADFRIbulbGU10WS400lm.json
+++ b/core/config/devices/TRADFRIbulbGU10WS400lm/TRADFRIbulbGU10WS400lm.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRIbulbGU10WW400lm/TRADFRIbulbGU10WW400lm.json
+++ b/core/config/devices/TRADFRIbulbGU10WW400lm/TRADFRIbulbGU10WW400lm.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRItransformer10W/TRADFRItransformer10W.json
+++ b/core/config/devices/TRADFRItransformer10W/TRADFRItransformer10W.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TRADFRItransformer30W/TRADFRItransformer30W.json
+++ b/core/config/devices/TRADFRItransformer30W/TRADFRItransformer30W.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/TS0111/TS0111.json
+++ b/core/config/devices/TS0111/TS0111.json
@@ -26,7 +26,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include13 2": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/TS0121/TS0121.json
+++ b/core/config/devices/TS0121/TS0121.json
@@ -27,8 +27,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/TS0121__TYZB01_zanh6v1o/TS0121__TYZB01_zanh6v1o.json
+++ b/core/config/devices/TS0121__TYZB01_zanh6v1o/TS0121__TYZB01_zanh6v1o.json
@@ -27,8 +27,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/TS0121__TZ3000_g5xawfcq/TS0121__TZ3000_g5xawfcq.json
+++ b/core/config/devices/TS0121__TZ3000_g5xawfcq/TS0121__TZ3000_g5xawfcq.json
@@ -27,8 +27,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/TS0302/TS0302.json
+++ b/core/config/devices/TS0302/TS0302.json
@@ -20,7 +20,10 @@
             "Stop": {
                 "use": "zbCmd-0102-Stop"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/TS0503B__TZ3000_i8l0nqdu/TS0503B__TZ3000_i8l0nqdu.json
+++ b/core/config/devices/TS0503B__TZ3000_i8l0nqdu/TS0503B__TZ3000_i8l0nqdu.json
@@ -11,8 +11,14 @@
         },
         "type": "Tuya DC5V-24V LED controller",
         "commands": {
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "On": {
                 "use": "zbCmd-0006-On",
                 "isVisible": 1

--- a/core/config/devices/TS0505A/TS0505A.json
+++ b/core/config/devices/TS0505A/TS0505A.json
@@ -19,7 +19,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0000&attrId=4000"
             },
-            "include16": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "Groups": {
                 "use": "Group-Membership"
             },

--- a/core/config/devices/TS0505A__TZ3000_riwp3k79/TS0505A__TZ3000_riwp3k79.json
+++ b/core/config/devices/TS0505A__TZ3000_riwp3k79/TS0505A__TZ3000_riwp3k79.json
@@ -20,7 +20,10 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0000&attrId=4000"
             },
-            "include16": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "Groups": {
                 "use": "Group-Membership"
             },

--- a/core/config/devices/TS0505B__TZ3000_12sxjap4/TS0505B__TZ3000_12sxjap4.json
+++ b/core/config/devices/TS0505B__TZ3000_12sxjap4/TS0505B__TZ3000_12sxjap4.json
@@ -11,8 +11,14 @@
         },
         "type": "Yandhi E27 Bulb",
         "commands": {
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "On": {
                 "use": "zbCmd-0006-On",
                 "isVisible": 1

--- a/core/config/devices/TS0601__TZE200_la2c2uo9/TS0601__TZE200_la2c2uo9.json
+++ b/core/config/devices/TS0601__TZE200_la2c2uo9/TS0601__TZE200_la2c2uo9.json
@@ -27,6 +27,7 @@
             },
             "Status": {
                 "use": "zb-0006-OnOff",
+                "nextLine": "after",
                 "isVisible": 1
             },
             "Set Level": {

--- a/core/config/devices/Teleruptor/Teleruptor.json
+++ b/core/config/devices/Teleruptor/Teleruptor.json
@@ -28,8 +28,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/WS2812_light_controller/WS2812_light_controller.json
+++ b/core/config/devices/WS2812_light_controller/WS2812_light_controller.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/WarningDevice-EF-3.0/WarningDevice-EF-3.0.json
+++ b/core/config/devices/WarningDevice-EF-3.0/WarningDevice-EF-3.0.json
@@ -14,8 +14,14 @@
         },
         "commands": {
             "include4": "zb-0000-ZCLVersion",
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",
@@ -37,7 +43,6 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0000&attrId=4000"
             },
-
             "Test SOUND & FLASH": {
                 "use": "zbCmd-0502-StartWarning",
                 "params": "ep=01&mode=burglar",

--- a/core/config/devices/WarningDevice/WarningDevice.json
+++ b/core/config/devices/WarningDevice/WarningDevice.json
@@ -11,8 +11,14 @@
         "type": "Alarm Smart Siren M420-2Evert1.2 HS2WD-E",
         "commands": {
             "include4": "zb-0000-ZCLVersion",
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ZB-CL01/ZB-CL01.json
+++ b/core/config/devices/ZB-CL01/ZB-CL01.json
@@ -75,8 +75,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/ZB-RGBCW/ZB-RGBCW.json
+++ b/core/config/devices/ZB-RGBCW/ZB-RGBCW.json
@@ -28,8 +28,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ZLL-DimmableLigh/ZLL-DimmableLigh.json
+++ b/core/config/devices/ZLL-DimmableLigh/ZLL-DimmableLigh.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/ZLO-DimmableLight/ZLO-DimmableLight.json
+++ b/core/config/devices/ZLO-DimmableLight/ZLO-DimmableLight.json
@@ -35,8 +35,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/ZLO-ExtendedColor/ZLO-ExtendedColor.json
+++ b/core/config/devices/ZLO-ExtendedColor/ZLO-ExtendedColor.json
@@ -72,8 +72,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/ctrl_ln1.aq1/ctrl_ln1.aq1.json
+++ b/core/config/devices/ctrl_ln1.aq1/ctrl_ln1.aq1.json
@@ -41,8 +41,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/ctrl_ln2.aq1/ctrl_ln2.aq1.json
+++ b/core/config/devices/ctrl_ln2.aq1/ctrl_ln2.aq1.json
@@ -76,8 +76,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/ctrl_neutral1/ctrl_neutral1.json
+++ b/core/config/devices/ctrl_neutral1/ctrl_neutral1.json
@@ -18,8 +18,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/ctrl_neutral2/ctrl_neutral2.json
+++ b/core/config/devices/ctrl_neutral2/ctrl_neutral2.json
@@ -85,8 +85,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/diy-routeur/diy-routeur.json
+++ b/core/config/devices/diy-routeur/diy-routeur.json
@@ -11,7 +11,10 @@
         },
         "type": "diy-routeur",
         "commands": {
-            "include24": "Identify",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/light.aqcn02/light.aqcn02.json
+++ b/core/config/devices/light.aqcn02/light.aqcn02.json
@@ -52,8 +52,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "include25 2": "Scene-Membership",
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",

--- a/core/config/devices/plug.mmeu01/plug.mmeu01.json
+++ b/core/config/devices/plug.mmeu01/plug.mmeu01.json
@@ -31,7 +31,10 @@
             "include13 2 2": "VoltagePrise",
             "include13 2 2 2": "CurrentPrise_mA",
             "include13 2 2 2 2": "temperaturePrise",
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/plug/plug.json
+++ b/core/config/devices/plug/plug.json
@@ -29,7 +29,10 @@
             "include11": "conso",
             "include12": "Xiaomi-ff01",
             "include13": "puissance",
-            "include13 2": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/plug01OutDoor/plug01OutDoor.json
+++ b/core/config/devices/plug01OutDoor/plug01OutDoor.json
@@ -27,8 +27,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0006",

--- a/core/config/devices/switch.b2nacn02/switch.b2nacn02.json
+++ b/core/config/devices/switch.b2nacn02/switch.b2nacn02.json
@@ -77,8 +77,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/switch.l1aeu1/switch.l1aeu1.json
+++ b/core/config/devices/switch.l1aeu1/switch.l1aeu1.json
@@ -12,7 +12,10 @@
         },
         "type": "Aqara H1 smart wall switch",
         "commands": {
-            "include13 2": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "etat": {
                 "use": "zb-0006-OnOff",
                 "isVisible": 1

--- a/core/config/devices/switch.l2aeu1/switch.l2aeu1.json
+++ b/core/config/devices/switch.l2aeu1/switch.l2aeu1.json
@@ -12,9 +12,15 @@
             "icon": "Aqara-WallSwitchH1-Double"
         },
         "commands": {
-            "include13 2": "Group-Membership",
-
-            "Status 1": { "use": "zb-0006-OnOff", "params": "ep=01", "isVisible": 1 },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
+            "Status 1": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=01",
+                "isVisible": 1
+            },
             "On 1": {
                 "use": "zbCmd-0006-On",
                 "params": "ep=01",
@@ -29,7 +35,11 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0006&attrId=0000"
             },
-            "Status 2": { "use": "zb-0006-OnOff", "params": "ep=02", "isVisible": 1 },
+            "Status 2": {
+                "use": "zb-0006-OnOff",
+                "params": "ep=02",
+                "isVisible": 1
+            },
             "On 2": {
                 "use": "zbCmd-0006-On",
                 "params": "ep=02",

--- a/core/config/devices/zigbeeColorDimmableLight/zigbeeColorDimmableLight.json
+++ b/core/config/devices/zigbeeColorDimmableLight/zigbeeColorDimmableLight.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/zigbeeColortemperaturelight/zigbeeColortemperaturelight.json
+++ b/core/config/devices/zigbeeColortemperaturelight/zigbeeColortemperaturelight.json
@@ -53,8 +53,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/zigbeeDimmableLight/zigbeeDimmableLight.json
+++ b/core/config/devices/zigbeeDimmableLight/zigbeeDimmableLight.json
@@ -36,8 +36,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include24": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/zigbeeExtendedcolorlight/zigbeeExtendedcolorlight.json
+++ b/core/config/devices/zigbeeExtendedcolorlight/zigbeeExtendedcolorlight.json
@@ -73,8 +73,14 @@
                 "use": "zbReadAttribute",
                 "params": "clustId=0008&attrId=0000"
             },
-            "include16": "Identify",
-            "include25": "Group-Membership",
+            "Identify": {
+                "use": "Identify",
+                "isVisible": 1
+            },
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "Bind-0006-ToZigate": {
                 "use": "zbBindToZigate",
                 "params": "clustId=0008",

--- a/core/config/devices/zigbeeShade/zigbeeShade.json
+++ b/core/config/devices/zigbeeShade/zigbeeShade.json
@@ -20,7 +20,10 @@
             "Stop": {
                 "use": "zbCmd-0102-Stop"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/config/devices/zigbeeWindowCoveringDevice/zigbeeWindowCoveringDevice.json
+++ b/core/config/devices/zigbeeWindowCoveringDevice/zigbeeWindowCoveringDevice.json
@@ -20,7 +20,10 @@
             "Stop": {
                 "use": "zbCmd-0102-Stop"
             },
-            "include25": "Group-Membership",
+            "Groups": {
+                "use": "Group-Membership",
+                "isVisible": 1
+            },
             "SWBuildID": {
                 "use": "zb-0000-SWBuildID"
             },

--- a/core/php/AbeilleCliToQueue.php
+++ b/core/php/AbeilleCliToQueue.php
@@ -43,11 +43,11 @@
     if ($action == "sendMsg") {
         if (isset($dbgTcharp38)) logDebug("CliToQueue: action=".$action);
 
-        // Default target queue = '$abQueues['xmlToAbeille']['id']'
+        // Default target queue = '$abQueues['xToAbeille']['id']'
         if (isset($_GET['queueId']))
             $queueId = $_GET['queueId'];
         else
-            $queueId = $abQueues['xmlToAbeille']['id'];
+            $queueId = $abQueues['xToAbeille']['id'];
         if (isset($dbgTcharp38)) logDebug("CliToQueue: queueId=".$queueId);
         $queue = msg_get_queue($queueId);
         if ($queue === false) {
@@ -55,7 +55,7 @@
             return;
         }
 
-        if (in_array($queueId, [$abQueues['xmlToAbeille']['id'], $abQueues['xToCmd']['id']])) {
+        if (in_array($queueId, [$abQueues['xToAbeille']['id'], $abQueues['xToCmd']['id']])) {
             $topic =  $_GET['topic'];
             $topic = str_replace('_', '/', $topic);
             $payload = $_GET['payload'];
@@ -207,7 +207,7 @@
         }
 
         if ($action == "reinit") {
-            $queue = msg_get_queue($abQueues['xmlToAbeille']['id']);
+            $queue = msg_get_queue($abQueues['xToAbeille']['id']);
             $msg = array(
                 'topic' => "CmdCreate".$eqNet."/".$eqAddr."/resetFromJson",
                 'payload' => '',

--- a/core/php/AbeilleCmd-Tuya.php
+++ b/core/php/AbeilleCmd-Tuya.php
@@ -2,6 +2,8 @@
     // Tuya specific commands (to device) functions.
     // Included by 'AbeilleCmd.php'
 
+    $tuyaTransId = 0; // Transaction ID: 0 to 255
+
     // Types reminder
     // Type	    TypeId  LengthInBytes	Description
     // raw	    0x00	N	            Corresponds to raw datapoint (module pass-through)
@@ -52,7 +54,7 @@
             $dpType = "01"; // Bool
             $dpData = sprintf("%02X", $data);
             break;
-        // Send percent data in (0-1000) range with input in 0-100 range
+        // Send percent data in 0-1000 range with input in 0-100 range
         case "setPercent1000":
             if (!isset($abCmd['dpId'])) {
                 cmdLog('debug', "    ERROR: Undefined dpId for '".$cmd."'");
@@ -60,7 +62,7 @@
             }
             $dpId = $abCmd['dpId'];
             $dpType = "02"; // Value
-            $dpData = sprintf("%04X", $data * 10);
+            $dpData = sprintf("%08X", $data * 10);
             break;
 
         default:
@@ -77,4 +79,13 @@
         return $dp;
     }
 
+    // Returns Tuya specific transaction ID
+    function tuyaGetTransId() {
+        global $tuyaTransId;
+        $tuyaTransId++;
+        if ($tuyaTransId > 255)
+            $tuyaTransId = 0;
+        $tId = sprintf("%02X", $tuyaTransId);
+        return $tId;
+    }
 ?>

--- a/core/php/AbeilleParser-Tuya.php
+++ b/core/php/AbeilleParser-Tuya.php
@@ -308,7 +308,7 @@
         // Use exemple:  "02": { "function": "rcvValue", "info": "0008-01-0000" },
         case "rcvValue": // Value sent as Jeedom info
             $val = hexdec($dp['data']);
-            $logMsg = "  ".$dp['m']." => Info=".$info.", Val=".$val;
+            $logMsg = "  ".$dp['m']." => 'rcvValue' => Info=".$info.", Val=".$val;
             $attributeN = array(
                 'name' => $info,
                 'value' => $val,
@@ -318,7 +318,7 @@
         case "rcvValueDiv": // Divided value sent as Jeedom info
             $val = hexdec($dp['data']);
             $val = $val / $div;
-            $logMsg = "  ".$dp['m']." => Info=".$info.", Div=".$div." => Val=".$val;
+            $logMsg = "  ".$dp['m']." => 'rcvValueDiv' => Info=".$info.", Div=".$div." => Val=".$val;
             $attributeN = array(
                 'name' => $info,
                 'value' => $val,
@@ -328,7 +328,7 @@
         case "rcvValueMult": // Multiplied value sent as Jeedom info
             $val = hexdec($dp['data']);
             $val = $val * $mult;
-            $logMsg = "  ".$dp['m']." => Info=".$info.", Mult=".$mult." => Val=".$val;
+            $logMsg = "  ".$dp['m']." => 'rcvValueMult' => Info=".$info.", Mult=".$mult." => Val=".$val;
             $attributeN = array(
                 'name' => $info,
                 'value' => $val,
@@ -340,7 +340,7 @@
                 $val = 1;
             else
                 $val = 0;
-            $logMsg = "  ".$dp['m']." => Info=".$info.", Val=".$val;
+            $logMsg = "  ".$dp['m']." => 'rcvValue0Is1' => Info=".$info.", Val=".$val;
             $attributeN = array(
                 'name' => $info,
                 'value' => $val,

--- a/core/php/AbeilleParser.php
+++ b/core/php/AbeilleParser.php
@@ -183,8 +183,12 @@
         Msg format is now flexible and can transport a bunch of infos coming from zigbee event instead of splitting them
         into several messages to Abeille. */
     function msgToAbeille2($msg) {
-        global $queueParserToAbeille2;
-        if (msg_send($queueParserToAbeille2, 1, json_encode($msg), false, false, $errCode) == false) {
+        // global $queueParserToAbeille2;
+        // if (msg_send($queueParserToAbeille2, 1, json_encode($msg), false, false, $errCode) == false) {
+        //     parserLog("debug", "msgToAbeille2(): ERROR ".$errCode);
+        // }
+        global $queueXToAbeille;
+        if (msg_send($queueXToAbeille, 1, json_encode($msg), false, false, $errCode) == false) {
             parserLog("debug", "msgToAbeille2(): ERROR ".$errCode);
         }
     }
@@ -311,7 +315,8 @@
     }
 
     // Inits
-    $queueParserToAbeille2 = msg_get_queue($abQueues["parserToAbeille2"]["id"]);
+    // $queueParserToAbeille2 = msg_get_queue($abQueues["parserToAbeille2"]["id"]);
+    $queueXToAbeille = msg_get_queue($abQueues["xToAbeille"]["id"]);
 
     /* Any device to monitor ?
        It is indicated by 'monitor' key in Jeedom 'config' table. */

--- a/core/php/AbeilleTest.php
+++ b/core/php/AbeilleTest.php
@@ -370,7 +370,7 @@
             case 200:
                 echo "Send a Systeme Message to the Ruche to be used by a scenario by the user\n";
                 // public static function publishMosquitto($queueId, $priority, $topic, $payload)
-                Abeille::publishMosquitto($abQueues["abeilleToAbeille"]["id"], PRIO_NORM, "Abeille1/0000/SystemMessage", "Le message");
+                Abeille::publishMosquitto($abQueues["xToAbeille"]["id"], PRIO_NORM, "Abeille1/0000/SystemMessage", "Le message");
                 break;
             case 201:
                 echo "Send a Systeme Message to the Ruche1 and clean it after 5 sec\n";
@@ -400,7 +400,7 @@
                 break;
             case 205:
                 echo "Send a Systeme Message to the Ruche to create an eq based on a template\n";
-                Abeille::publishMosquitto($abQueues["abeilleToAbeille"]["id"], PRIO_NORM, "Abeille1/FFFF/0000-01-0005", "BSO");
+                Abeille::publishMosquitto($abQueues["xToAbeille"]["id"], PRIO_NORM, "Abeille1/FFFF/0000-01-0005", "BSO");
                 break;
         }
     }

--- a/core/php/AbeilleZigate.php
+++ b/core/php/AbeilleZigate.php
@@ -188,18 +188,16 @@
             return -1;
         }
 
-        logMessage('debug', 'Interrogation de la Zigate sur port '.$zgPort);
+        logMessage('debug', 'Interrogating zigate on port '.$zgPort);
         $zgMsg = zgComposeMsg("0010");
         $status = zgWrite($zgF, $zgMsg); // Sending "Get Version" command
         $zgMsg = "";
-        if ($status == 0) {
+        while ($status == 0) {
             $status = zgRead($zgF, $zgMsg); // Expecting 8000 'status' frame
-        }
-        if ($status == 0) {
-            $zgMsgType = substr($zgMsg, 0, 4);
-            if ($zgMsgType != "8000") {
-                logMessage('debug', 'Mauvaise réponse. 8000 attendu.');
-                $status = -1;
+            if ($status == 0) {
+                $zgMsgType = substr($zgMsg, 0, 4);
+                if ($zgMsgType == "8000")
+                    break;
             }
         }
         if ($status == 0)
@@ -207,7 +205,7 @@
         if ($status == 0) {
             $zgMsgType = substr($zgMsg, 0, 4);
             if ($zgMsgType != "8010") {
-                logMessage('debug', 'Mauvaise réponse. 8010 attendu.');
+                logMessage('debug', 'Unexpected answer (got='.$zgMsgType.', exp=8010).');
                 $status = -1;
             } else {
                 $major = substr($zgMsg, 10, 4);

--- a/desktop/modal/AbeilleHealth.modal.php
+++ b/desktop/modal/AbeilleHealth.modal.php
@@ -104,19 +104,19 @@ Démons:
 
             echo "\n\n\n<tr>";
 
-            // Ruche
+            // Network (AbeilleX)
             echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$net.'</span></td>';
 
-            // Module
+            // Device name
             echo '<td><a href="'.$eqLogic->getLinkToConfiguration().'" style="text-decoration: none;">'.$eqLogic->getHumanName(true).'</a></td>';
 
-            // Module type
-            // TODO: Put real device type instead of icon
-            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$eqLogic->getConfiguration('ab::icon').'</span></td>';
+            // Device type
+            $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
+            $type = isset($eqModel['type']) ? $eqModel['type'] : '?';
+            echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$type.'</span></td>';
 
             // ID
             // echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$eqLogic->getId().'</span></td>';
-
 
             // Short Address
             echo '<td><span class="label label-info" style="font-size: 1em; cursor: default;">'.$addr.'</span></td>';

--- a/docs/fr_FR/Changelog.rst
+++ b/docs/fr_FR/Changelog.rst
@@ -1,6 +1,15 @@
 ChangeLog
 =========
 
+- Interne: Suppression queue obsolete 'parserToAbeille'.
+- Interne: Optimisation queues 'xmlToAbeille'/'cmdToAbeille'/'abeilleToAbeille' => 'xToAbeille'.
+- Page config: Test de port: Amélioration mineure.
+- Interne: Optimisation queues dans deamon(): 'parserToAbeille2' => 'xToAbeille'.
+- Page santé: Affichage du type d'équipement au lieu de son icone.
+- Interne: Ajout type 'Zigate' à l'équipement 'Ruche'.
+- Interne: Format JSON eq: Mise-à-jour 'Identify' & 'Groups'.
+- Interne: Support Tuya: Amélioration 'transId' + 'setPercent1000'.
+
 220829-BETA-1
 -------------
 


### PR DESCRIPTION
- Interne: Suppression queue obsolete 'parserToAbeille'.
- Interne: Optimisation queues 'xmlToAbeille'/'cmdToAbeille'/'abeilleToAbeille' => 'xToAbeille'.
- Page config: Test de port: Amélioration mineure.
- Interne: Optimisation queues dans deamon(): 'parserToAbeille2' => 'xToAbeille'.
- Page santé: Affichage du type d'équipement au lieu de son icone.
- Interne: Ajout type 'Zigate' à l'équipement 'Ruche'.
- Interne: Format JSON eq: Mise-à-jour 'Identify' & 'Groups'.
- Interne: Support Tuya: Amélioration 'transId' + 'setPercent1000'.
