### PR TITLE
Xiaomi tags + default historization

### DIFF
--- a/core/class/AbeilleParser.class.php
+++ b/core/class/AbeilleParser.class.php
@@ -2501,11 +2501,11 @@
                     $fcfTxt .= "/ManufCode=".$manufCode;
                     $sqn = substr($payload, 32, 2); // Sequence Number
                     $cmd = substr($payload, 34, 2); // Command
-                    $msg = substr($payload, 36);
+                    $pl = substr($payload, 36);
                 } else {
                     $sqn = substr($payload, 28, 2); // Sequence Number
                     $cmd = substr($payload, 30, 2); // Command
-                    $msg = substr($payload, 32);
+                    $pl = substr($payload, 32);
                 }
                 if ($frameType == 0) // General command
                     $msgDecoded = "  FCF=".$fcf."/".$fcfTxt.", SQN=".$sqn.", cmd=".$cmd.'/'.zbGetZCLGlobalCmdName($cmd);
@@ -2513,16 +2513,21 @@
                     $msgDecoded = "  FCF=".$fcf."/".$fcfTxt.", SQN=".$sqn.", cmd=".$cmd.'/'.zbGetZCLClusterCmdName($clustId, $cmd);
                 parserLog('debug', $msgDecoded);
 
-                if ($fcf == '1C') {
+                // if ($fcf == '1C') {
                     if ($manufCode == '115F') {
                         parserLog('debug', "  Xiaomi FCC0 cluster");
-                        if ($cmd == '0A') {
-                            $Attribut = substr($payload,38, 2).substr($payload,36, 2);
+                        parserLog('debug', "  PL=".$pl);
+                        if ($cmd == '0A') { // Report attributes
+                            $Attribut = substr($pl, 2, 2).substr($pl, 0, 2);
+                            $dataType = substr($pl, 4, 2);
                             if ($Attribut=='00F7') {
-                                $dataType = substr($payload,40, 2);
                                 if ($dataType == "41") { // 0x41 Octet stream
-                                    $dataLength = hexdec(substr($payload,42, 2));
-                                    $fcc0 = $this->decodeFF01(substr($payload, 44, $dataLength*2));
+                                    // WORK ONGOING
+                                    xiaomiDecodeTags(substr($pl, 8));
+                                    // WORK ONGOING
+
+                                    $dataLength = hexdec(substr($pl, 6, 2));
+                                    $fcc0 = $this->decodeFF01(substr($pl, 8, $dataLength*2));
                                     // parserLog('debug', "  ".json_encode($fcc0));
 
                                     // $this->msgToAbeille($dest."/".$srcAddr, '0006', '01-0000', $fcc0["Etat SW 1 Binaire"]["valueConverted"]);    // On Off Etat
@@ -2541,7 +2546,7 @@
                             }
                         }
                     }
-                }
+                // }
             } // End profile 0104 cluster FCC0
 
             /* WARNING:
@@ -5171,6 +5176,10 @@
                 else if (($attrId == "FF01") && ($attrSize == "001D")) {
                     // Assuming $dataType == "42"
 
+                    // FOR INFO ONLY. WORK ONGOING.
+                    xiaomiDecodeTags($Attribut);
+                    // FOR INFO ONLY. WORK ONGOING.
+
                     // $voltage        = hexdec(substr($payload, 24 + 2 * 2 + 2, 2).substr($payload, 24 + 2 * 2, 2));
                     $voltage = hexdec(substr($Attribut, 2 * 2 + 2, 2).substr($Attribut, 2 * 2, 2));
                     // $etat           = substr($payload, 80, 2);
@@ -5250,6 +5259,10 @@
                     // Assuming $dataType == "42"
 
                     parserLog('debug', '  Xiaomi proprietary (Temp square sensor)');
+
+                    // FOR INFO ONLY. WORK ONGOING.
+                    xiaomiDecodeTags($Attribut);
+                    // FOR INFO ONLY. WORK ONGOING.
 
                     $voltage        = hexdec(substr($Attribut, 2 * 2 + 2, 2).substr($Attribut, 2 * 2, 2));
                     $temperature    = unpack("s", pack("s", hexdec(substr($Attribut, 21 * 2 + 2, 2).substr($Attribut, 21 * 2, 2))))[1];

--- a/core/class/AbeilleTools.class.php
+++ b/core/class/AbeilleTools.class.php
@@ -447,20 +447,23 @@
                                 $newCmd[$cmd1]['subType'] = $cmd2['subType'];
                             if (isset($cmd2['unit']))
                                 $newCmd[$cmd1]['unit'] = $cmd2['unit'];
-                            if (isset($cmd2['minValue']))
-                                $newCmd[$cmd1]['configuration']['minValue'] = $cmd2['minValue'];
-                            if (isset($cmd2['maxValue']))
-                                $newCmd[$cmd1]['configuration']['maxValue'] = $cmd2['maxValue'];
+                            if (isset($cmd2['isHistorized']))
+                                $newCmd[$cmd1]['isHistorized'] = $cmd2['isHistorized'];
                             if (isset($cmd2['genericType']))
                                 $newCmd[$cmd1]['genericType'] = $cmd2['genericType'];
-                            if (isset($cmd2['trigOut']))
-                                $newCmd[$cmd1]['configuration']['trigOut'] = $cmd2['trigOut'];
-                            if (isset($cmd2['trigOutOffset']))
-                                $newCmd[$cmd1]['configuration']['trigOutOffset'] = $cmd2['trigOutOffset'];
                             if (isset($cmd2['logicalId']))
                                 $newCmd[$cmd1]['logicalId'] = $cmd2['logicalId'];
                             if (isset($cmd2['invertBinary']))
                                 $newCmd[$cmd1]['invertBinary'] = $cmd2['invertBinary'];
+
+                            if (isset($cmd2['minValue']))
+                                $newCmd[$cmd1]['configuration']['minValue'] = $cmd2['minValue'];
+                            if (isset($cmd2['maxValue']))
+                                $newCmd[$cmd1]['configuration']['maxValue'] = $cmd2['maxValue'];
+                            if (isset($cmd2['trigOut']))
+                                $newCmd[$cmd1]['configuration']['trigOut'] = $cmd2['trigOut'];
+                            if (isset($cmd2['trigOutOffset']))
+                                $newCmd[$cmd1]['configuration']['trigOutOffset'] = $cmd2['trigOutOffset'];
                             if (isset($cmd2['historizeRound']))
                                 $newCmd[$cmd1]['configuration']['historizeRound'] = $cmd2['historizeRound'];
                             if (isset($cmd2['calculValueOffset']))

--- a/core/config/commands/zb-0400-MeasuredValue.json
+++ b/core/config/commands/zb-0400-MeasuredValue.json
@@ -4,6 +4,7 @@
         "name": "MeasuredValue",
         "subType": "numeric",
         "template": "badge",
+        "isHistorized": "1",
         "configuration": {
             "historizeRound": "0"
         },

--- a/core/config/commands/zb-0402-MeasuredValue.json
+++ b/core/config/commands/zb-0402-MeasuredValue.json
@@ -4,6 +4,7 @@
         "name": "MeasuredValue",
         "subType": "numeric",
         "template": "badge",
+        "isHistorized": "1",
         "configuration": {
             "historizeRound": "1"
         },

--- a/core/config/commands/zb-0403-MeasuredValue.json
+++ b/core/config/commands/zb-0403-MeasuredValue.json
@@ -3,6 +3,7 @@
         "comment": "0403/Pressure cluster, attrib 0000/MeasuredValue",
         "subType": "numeric",
         "template": "badge",
+        "isHistorized": "1",
         "configuration": {
         },
         "type": "info",

--- a/core/config/commands/zb-0405-MeasuredValue.json
+++ b/core/config/commands/zb-0405-MeasuredValue.json
@@ -4,6 +4,7 @@
         "name": "MeasuredValue",
         "subType": "numeric",
         "template": "badge",
+        "isHistorized": "1",
         "configuration": {
             "historizeRound": "0"
         },

--- a/core/config/devices/weather/weather.json
+++ b/core/config/devices/weather/weather.json
@@ -24,13 +24,13 @@
                 "isVisible": 1,
                 "isHistorized": 1
             },
-            "Humidity": {
-                "use": "zb-0405-MeasuredValue",
-                "isVisible": 1
-            },
             "Pressure": {
                 "use": "zb-0403-MeasuredValue",
                 "isVisible": 0
+            },
+            "Humidity": {
+                "use": "zb-0405-MeasuredValue",
+                "isVisible": 1
             },
             "include7": "Xiaomi-ff01"
         }

--- a/core/php/AbeilleParser-Xiaomi.php
+++ b/core/php/AbeilleParser-Xiaomi.php
@@ -1,0 +1,50 @@
+
+<?php
+    // Xiaomi specific parser functions
+    // Included by 'AbeilleParser.php'
+
+    // WORK ONGOING. Not all functions migrated their yet.
+
+    // Decode Xiaomi tags
+    // Based on https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Xiaomi-manufacturer-specific-clusters%2C-attributes-and-attribute-reporting
+    function xiaomiDecodeTags($pl) {
+        $tagsList = array(
+            "01-21" => array( "desc" => "Battery-Volt" ),
+            "03-28" => array( "desc" => "Device-Temp" ),
+            "0A-21" => array( "desc" => "Parent-Addr" ),
+            "0B-21" => array( "desc" => "Light-Level" ),
+            "64-10" => array( "desc" => "OnOff" ), // Or Open/closed
+            "64-29" => array( "desc" => "Temperature" ),
+            "65-21" => array( "desc" => "Humidity" ),
+            "66-2B" => array( "desc" => "Pressure" ),
+            "95-39" => array( "desc" => "Current" ), // Or Consumption
+            "96-39" => array( "desc" => "Voltage" ),
+            "97-39" => array( "desc" => "Consumption" ),
+            "98-39" => array( "desc" => "Power" ),
+        );
+
+        $l = strlen($pl);
+        for ($i = 0; $i < $l; ) {
+            $tagId = substr($pl, $i + 0, 2);
+            $typeId = substr($pl, $i + 2, 2);
+
+            $type = zbGetDataType($typeId);
+            $size = $type['size'];
+            if ($size == 0) {
+                parserLog('debug', '  Tag='.$tagId.', Type='.$typeId.'/'.$type['short'].' SIZE 0');
+                break;
+            }
+            $data = substr($pl, $i + 4, $size * 2);
+            if ($size > 1)
+                $data = AbeilleTools::reverseHex($data);
+            $i += 4 + ($size * 2);
+
+            $idx = strtoupper($tagId.'-'.$typeId);
+            if (isset($tagsList[$idx]))
+                $tagName = '/'.$tagsList[$idx]['desc'];
+            else
+                $tagName = '';
+            parserLog('debug', '  Tag='.$tagId.$tagName.', Type='.$typeId.'/'.$type['short'].', Data='.$data);
+        }
+    }
+?>

--- a/core/php/AbeilleParser.php
+++ b/core/php/AbeilleParser.php
@@ -37,6 +37,7 @@
     include_once __DIR__.'/../class/Abeille.class.php';
     include_once __DIR__.'/AbeilleOTA.php';
     include_once __DIR__.'/AbeilleParser-Tuya.php'; // Tuya specific functions
+    include_once __DIR__.'/AbeilleParser-Xiaomi.php'; // Xiaomi specific functions
 
     // Needed for decode8701 and decode8702
     // Voir https://github.com/fairecasoimeme/ZiGate/issues/161

--- a/core/php/AbeilleZigbeeConst.php
+++ b/core/php/AbeilleZigbeeConst.php
@@ -73,6 +73,12 @@
         return $unk;
     }
 
+    /* Returns size (in B) of the given data type ID */
+    function zbGetDataSize($id) {
+        $type = zbGetDataType($id);
+        return $type['size'];
+    }
+
     /* Returns 'Mgmt_lqi_rsp' bitmap description as string */
     function zbGetMgmtLqiRspBitmap($bitMap) {
         $bitMap = hexdec($bitMap);

--- a/docs/fr_FR/Changelog.rst
+++ b/docs/fr_FR/Changelog.rst
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+- Interne: Parser: Xiaomi tags decode update.
+- Modèles: Historisation activée par défaut pour 0400/0402/0403 & 0405 clusters attr 0000.
+- Modèles: Surcharge possible de 'isHistorized'.
+
 221104-BETA-1
 -------------
 


### PR DESCRIPTION
- Interne: Parser: Xiaomi tags decode update.
- Modèles: Historisation activée par défaut pour 0400/0402/0403 & 0405 clusters attr 0000.
- Modèles: Surcharge possible de 'isHistorized'.
