### PR TITLE
PowerCycle enabled (default)/disabled

### DIFF
--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -486,15 +486,18 @@ class Abeille extends eqLogic {
                 $lastComm = strtotime($lastComm);
             // log::add('Abeille', 'info', "lastComm2=".$lastComm);
             if ((time() - $lastComm) > (2 * 60)) {
-                log::add('Abeille', 'info', "Pas de réponse de la Zigate ".$zgId." depuis plus de 2min");
-                $zgType = $config['ab::zgType'.$zgId];
-                $zgPort = $config['ab::zgPort'.$zgId];
-                if (($zgType == "USB") || ($zgType == "USBv2")) {
-                    $dir = __DIR__."/../scripts";
-                    $cmd = "cd ".$dir."; ".system::getCmdSudo()." ./powerCycleUsb.sh ".$zgPort." 1>/tmp/jeedom/Abeille/powerCycleUsb.log 2>&1";
-                    log::add('Abeille', 'debug', 'Power cycling port \''.$zgPort.'\'');
-                    exec($cmd." &"); // Exec in background
-                } else if (($zgType == "PI") || ($zgType == "PIv2"))
+                log::add('Abeille', 'info', "Pas de réponse de la Zigate " . $zgId . " depuis plus de 2min (powerCycle)");
+                $zgType = $config['ab::zgType' . $zgId];
+                $zgPort = $config['ab::zgPort' . $zgId];
+                if ((($zgType == "USB") || ($zgType == "USBv2")) && ($config['ab::zgPowerCycle' . $zgId] == 'Y')) {
+                    $dir = __DIR__ . "/../scripts";
+                    $cmd = "cd " . $dir . "; " . system::getCmdSudo() . " ./powerCycleUsb.sh " . $zgPort . " 1>/tmp/jeedom/Abeille/powerCycleUsb.log 2>&1";
+                    log::add('Abeille', 'debug', 'Power cycling port \'' . $zgPort . '\'');
+                    exec($cmd . " &");
+                } // Exec in background
+                else {
+                    log::add('Abeille', 'Debug', 'Power cycle required but disabled on \'' . $zgId . '\''); }
+            } elseif (($zgType == "PI") || ($zgType == "PIv2")){
                     Abeille::msgToCmd(PRIO_NORM, "CmdAbeille".$zgId."/0000/resetZg");
             }
         }

--- a/core/class/AbeilleTools.class.php
+++ b/core/class/AbeilleTools.class.php
@@ -760,6 +760,7 @@
                 $config['ab::zgIeeeAddrOk'.$zgId] = config::byKey('ab::zgIeeeAddrOk'.$zgId, 'Abeille', 0);
                 $config['ab::zgIeeeAddr'.$zgId] = config::byKey('ab::zgIeeeAddr'.$zgId, 'Abeille', '');
                 $chan = config::byKey('ab::zgChan'.$zgId, 'Abeille', 'niet');
+                $config['ab::zgPowerCycle'.$zgId] = config::byKey('ab::zgPowerCycle'.$zgId, 'Abeille', 1);
                 if ($chan != 'niet')
                     $config['ab::zgChan'.$zgId] = $chan;
             }

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -205,6 +205,16 @@
                 echo '</select>';
             echo '</div>';
         echo '</div>';
+
+        echo '<div class="form-group">';
+            echo '<label class="col-lg-3 control-label" data-toggle="tooltip">{{PowerCycle : }}</label>';
+            echo '<div class="col-lg-4">';
+                echo '<select id="idSelZgPowerCycle' . $zgId . '" class="configKey form-control" data-l1key="ab::zgPowerCycle' . $zgId . '" onchange="statusChange(' . $zgId . ')" title="{{Activer ou désactiver le reset usb en cas de non communication.}}">';
+                    echo '<option value="Y" selected>{{Activée}}</option>';
+                    echo '<option value="N" selected>{{Désactivée}}</option>';
+                echo '</select>';
+            echo '</div>';
+        echo '</div>';
     }
 ?>
 


### PR DESCRIPTION
proposition pour rendre le powercycle désactivable.

Dans certains cas, le powercycle n'est pas possible ou souhaitable car pas géré directement par le système ou se trouve jeedom. par exemple, une vm ou un container docker/podman.

Cette proposition permet de désactiver l execution du script powercycle.sh par zigate.

Je n'ai pas essayé de lancer le script depuis un conteneur cependant comme je ne donne pas accès à `/sys/bus/usb/drivers/usb/bind` ça ne risque pas de fonctionner.