### PR TITLE
Possibilité de forcer le modèle d'un équipement

### DIFF
--- a/core/ajax/Abeille.ajax.php
+++ b/core/ajax/Abeille.ajax.php
@@ -1,6 +1,6 @@
 <?php
 
-    /* This file is part of Plugin abeille for jeedom.
+/* This file is part of Plugin abeille for jeedom.
      *
      * Plugin abeille for jeedom is free software: you can redistribute it and/or modify
      * it under the terms of the GNU General Public License as published by
@@ -16,709 +16,713 @@
      * along with Plugin abeille for jeedom. If not, see <http://www.gnu.org/licenses/>.
      */
 
-    /*
+/*
      * Targets for AJAX's requests
      */
 
-    /* Developers debug features */
-    require_once __DIR__.'/../config/Abeille.config.php'; // dbgFile constant + queues
-    if (file_exists(dbgFile)) {
-        /* Dev mode: enabling PHP errors logging */
-        error_reporting(E_ALL);
-        ini_set('error_log', __DIR__.'/../../../../log/AbeillePHP.log');
-        ini_set('log_errors', 'On');
-    }
+/* Developers debug features */
+require_once __DIR__ . '/../config/Abeille.config.php'; // dbgFile constant + queues
+if (file_exists(dbgFile)) {
+    /* Dev mode: enabling PHP errors logging */
+    error_reporting(E_ALL);
+    ini_set('error_log', __DIR__ . '/../../../../log/AbeillePHP.log');
+    ini_set('log_errors', 'On');
+}
 
-    function logToFile($logFile = '', $logLevel = '', $msg = "") {
-        if ($logLevel != '') {
-            if (AbeilleTools::getNumberFromLevel($logLevel) > AbeilleTools::getLogLevel())
-                return; // Nothing to do
-            /* Note: sprintf("%-5.5s", $loglevel) to have vertical alignment. Log level truncated to 5 chars => error/warn/info/debug */
-            $pref = '['.date('Y-m-d H:i:s').']['.sprintf("%-5.5s", $logLevel).'] ';
-        } else
-            $pref = '['.date('Y-m-d H:i:s').'] ';
+function logToFile($logFile = '', $logLevel = '', $msg = "")
+{
+    if ($logLevel != '') {
+        if (AbeilleTools::getNumberFromLevel($logLevel) > AbeilleTools::getLogLevel())
+            return; // Nothing to do
+        /* Note: sprintf("%-5.5s", $loglevel) to have vertical alignment. Log level truncated to 5 chars => error/warn/info/debug */
+        $pref = '[' . date('Y-m-d H:i:s') . '][' . sprintf("%-5.5s", $logLevel) . '] ';
+    } else
+        $pref = '[' . date('Y-m-d H:i:s') . '] ';
 
-        $logDir = __DIR__.'/../../../../log/';
-        /* TODO: How to align logLevel width for better visual aspect ? */
-        file_put_contents($logDir.$logFile, $pref.$msg."\n", FILE_APPEND);
-    }
+    $logDir = __DIR__ . '/../../../../log/';
+    /* TODO: How to align logLevel width for better visual aspect ? */
+    file_put_contents($logDir . $logFile, $pref . $msg . "\n", FILE_APPEND);
+}
 
-    /* Format then send msg to AbeilleCmd.
+/* Format then send msg to AbeilleCmd.
        Returns: true=ok, false=error */
-    function sendToCmd($topic, $payload = '') {
-        global $abQueues;
+function sendToCmd($topic, $payload = '')
+{
+    global $abQueues;
 
-        $queueId = $abQueues["xToCmd"]['id'];
-        $queue = msg_get_queue($queueId);
+    $queueId = $abQueues["xToCmd"]['id'];
+    $queue = msg_get_queue($queueId);
 
-        $msg = array();
-        $msg['topic']   = $topic;
-        $msg['payload'] = $payload;
-        $msgJson = json_encode($msg);
+    $msg = array();
+    $msg['topic']   = $topic;
+    $msg['payload'] = $payload;
+    $msgJson = json_encode($msg);
 
-        if (msg_send($queue, 1, $msgJson, false, false) == false) {
-            return false;
-        }
-        return true;
+    if (msg_send($queue, 1, $msgJson, false, false) == false) {
+        return false;
+    }
+    return true;
+}
+
+try {
+
+    require_once __DIR__ . '/../../../../core/php/core.inc.php';
+    require_once __DIR__ . '/../class/Abeille.class.php';
+    require_once __DIR__ . '/../php/AbeilleZigate.php';
+    include_once __DIR__ . '/../class/AbeilleTools.class.php'; // deamonlogFilter()/getRunningDaemons2()
+    require_once __DIR__ . '/../php/AbeilleInstall.php'; // checkIntegrity()
+    include_once __DIR__ . '/../php/AbeilleLog.php'; // logDebug()
+
+    include_file('core', 'authentification', 'php');
+    if (!isConnect('admin')) {
+        throw new Exception('401 Unauthorized');
     }
 
-    try {
+    ajax::init();
 
-        require_once __DIR__.'/../../../../core/php/core.inc.php';
-        require_once __DIR__.'/../class/Abeille.class.php';
-        require_once __DIR__.'/../php/AbeilleZigate.php';
-        include_once __DIR__.'/../class/AbeilleTools.class.php'; // deamonlogFilter()/getRunningDaemons2()
-        require_once __DIR__.'/../php/AbeilleInstall.php'; // checkIntegrity()
-        include_once __DIR__.'/../php/AbeilleLog.php'; // logDebug()
+    logDebug('Abeille.ajax.php: action=' . init('action'));
 
-        include_file('core', 'authentification', 'php');
-        if (!isConnect('admin')) {
-            throw new Exception('401 Unauthorized');
-        }
-
-        ajax::init();
-
-        logDebug('Abeille.ajax.php: action='.init('action'));
-
-        /* For Wifi Zigate
+    /* For Wifi Zigate
         - check 'Addr:Port' via ping
         - check socat installation
         */
-        if (init('action') == 'checkWifi') {
-            $zgPort = init('zgport'); // Addr:Port
-            $zgSSP = init('ssp'); // Socat serial port
+    if (init('action') == 'checkWifi') {
+        $zgPort = init('zgport'); // Addr:Port
+        $zgSSP = init('ssp'); // Socat serial port
 
-            /* TODO: Log old issue. Why the following message never gets out ? */
-            logToFile('AbeilleConfig.log', 'debug', 'Arret des démons');
-            abeille::deamon_stop(); // Stopping daemons
+        /* TODO: Log old issue. Why the following message never gets out ? */
+        logToFile('AbeilleConfig.log', 'debug', 'Arret des démons');
+        abeille::deamon_stop(); // Stopping daemons
 
-            /* Checks addr is responding to ping and socat is installed. */
-            $cmdToExec = "checkWifi.sh ".$zgPort;
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/'.$cmdToExec.' >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
+        /* Checks addr is responding to ping and socat is installed. */
+        $cmdToExec = "checkWifi.sh " . $zgPort;
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/' . $cmdToExec . ' >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        // $status = 0;
+
+        /* TODO */
+        /* Need 'AbeilleSocat' daemon to interrogate Wifi zigate */
+        // $nohup = "/usr/bin/nohup";
+        // $php = "/usr/bin/php";
+        // $dir = __DIR__."/../class/";
+        // log::add('AbeilleConfig.log', 'debug', 'Démarrage d\'un démon socat temporaire');
+        // $params = $zgSSP.' '.log::convertLogLevel(log::getLogLevel('Abeille')).' '.$zgPort;
+        // $log = " >>".log::getPathToLog('AbeilleConfig.log')." 2>&1";
+        // $cmd = $nohup." ".$php." ".$dir."AbeilleSocat.php"." ".$params.$log;
+        // exec("echo ".$cmd." >>".log::getPathToLog('AbeilleTOTO'));
+        // log::add('AbeilleConfig.log', 'debug', '  cmd='.$cmd);
+        // exec($cmd.' &');
+
+        /* Read Zigate FW version */
+        // $version = 0; // FW version
+        // if ($status == 0) {
+        // zg_SetLog("AbeilleConfig");
+        // $status = zgGetVersion($zgSSP, $version);
+        // }
+
+        logToFile('AbeilleConfig.log', 'debug', 'Redémarrage des démons');
+        abeille::deamon_start(); // Restarting daemons
+
+        ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
+    }
+
+    if (init('action') == 'checkSocat') {
+        $prefix = logGetPrefix(""); // Get log prefix
+        $cmd = '/bin/bash ' . __DIR__ . "/../scripts/checkSocat.sh | sed -e 's/^/" . $prefix . "/' >>" . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success(json_encode($status));
+    }
+
+    if (init('action') == 'installSocat') {
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/installSocat.sh >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success(json_encode($status));
+    }
+
+    if (init('action') == 'checkWiringPi') {
+        $prefix = logGetPrefix(""); // Get log prefix
+        $cmd = '/bin/bash ' . __DIR__ . "/../scripts/checkWiringPi.sh | sed -e 's/^/" . $prefix . "/' >>" . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success(json_encode($status));
+    }
+
+    if (init('action') == 'installWiringPi') {
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/installWiringPi.sh >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success();
+    }
+
+    if (init('action') == 'checkPiGpio') {
+        $prefix = logGetPrefix(""); // Get log prefix
+        $cmd = '/bin/bash python ' . __DIR__ . "/../scripts/checkPiGpio.py | sed -e 's/^/" . $prefix . "/' >>" . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success(json_encode($status));
+    }
+
+    if (init('action') == 'installPiGpio') {
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/installPiGpio.sh >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success();
+    }
+
+    if (init('action') == 'checkTTY') {
+        $zgPort = init('zgport');
+        $zgType = init('zgtype');
+        $zgGpioLib = init("zgGpioLib");
+
+        logSetConf('AbeilleConfig.log', true);
+        logMessage('info', 'Test de communication avec la Zigate; type=' . $zgType . ', port=' . $zgPort . ', GpioLib=' . $zgGpioLib);
+
+        Abeille::pauseDaemons(1);
+
+        /* Checks port exists and is not already used */
+        $prefix = logGetPrefix(""); // Get log prefix
+        $cmdToExec = "checkTTY.sh " . $zgPort . " " . $zgType . " " . $zgGpioLib . ' "' . $prefix . '"';
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/' . $cmdToExec . " >>" . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+
+        /* Read Zigate FW version */
+        $version = 0; // FW version
+        if ($status == 0) {
+            $status = zgGetVersion($zgPort, $version);
+        }
+
+        Abeille::pauseDaemons(0);
+
+        ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
+    }
+
+    if (init('action') == 'installTTY') {
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/installTTY.sh >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+        ajax::success();
+    }
+
+    /* Update FW but check parameters first, prior to shutdown daemon */
+    if (init('action') == 'updateFirmware') {
+        $zgType = init('zgtype'); // "PI" or "DIN"
+        $zgPort = init('zgport');
+        $zgGpioLib = init('zgGpioLib');
+        $zgFwFile = init('fwfile');
+        $erasePdm = init('erasePdm');
+        $zgId = init('zgId');
+
+        logSetConf('AbeilleConfig.log', true);
+        logMessage('debug', 'updateFirmware(' . $zgType . ', ' . $zgFwFile . ', ' . $zgGpioLib . ', ' . $zgPort . ')');
+
+        if ($zgType == "PI")
+            $script = "updateFirmware.sh";
+        else
+            $script = "updateFirmwareDIN.sh";
+
+        logMessage('debug', 'Checking parameters');
+        $cmdToExec = $script . " check " . $zgPort . " " . $zgGpioLib;
+        $cmd = '/bin/bash ' . __DIR__ . '/../scripts/' . $cmdToExec . ' >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd, $out, $status);
+
+        $version = 0; // FW version
+        if ($status == 0) {
+            Abeille::pauseDaemons(1);
+
+            /* Updating FW and reset Zigate */
+            $cmdToExec = $script . " flash " . $zgPort . " " . $zgGpioLib . " " . $zgFwFile;
+            $cmd = '/bin/bash ' . __DIR__ . '/../scripts/' . $cmdToExec . ' >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
             exec($cmd, $out, $status);
-            // $status = 0;
 
-            /* TODO */
-            /* Need 'AbeilleSocat' daemon to interrogate Wifi zigate */
-            // $nohup = "/usr/bin/nohup";
-            // $php = "/usr/bin/php";
-            // $dir = __DIR__."/../class/";
-            // log::add('AbeilleConfig.log', 'debug', 'Démarrage d\'un démon socat temporaire');
-            // $params = $zgSSP.' '.log::convertLogLevel(log::getLogLevel('Abeille')).' '.$zgPort;
-            // $log = " >>".log::getPathToLog('AbeilleConfig.log')." 2>&1";
-            // $cmd = $nohup." ".$php." ".$dir."AbeilleSocat.php"." ".$params.$log;
-            // exec("echo ".$cmd." >>".log::getPathToLog('AbeilleTOTO'));
-            // log::add('AbeilleConfig.log', 'debug', '  cmd='.$cmd);
-            // exec($cmd.' &');
-
-            /* Read Zigate FW version */
-            // $version = 0; // FW version
+            /* Reading FW version */
+            // Tcharp38 note: removed this
+            // When restarting Zigate, several messages exchanges before being able to ask for version
+            // To be revisited
             // if ($status == 0) {
-                // zg_SetLog("AbeilleConfig");
-                // $status = zgGetVersion($zgSSP, $version);
+            //     $status = zgGetVersion($zgPort, $version);
             // }
 
-            logToFile('AbeilleConfig.log', 'debug', 'Redémarrage des démons');
-            abeille::deamon_start(); // Restarting daemons
-
-            ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
-        }
-
-        if (init('action') == 'checkSocat') {
-            $prefix = logGetPrefix(""); // Get log prefix
-            $cmd = '/bin/bash '.__DIR__."/../scripts/checkSocat.sh | sed -e 's/^/".$prefix."/' >>".log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success(json_encode($status));
-        }
-
-        if (init('action') == 'installSocat') {
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/installSocat.sh >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success(json_encode($status));
-        }
-
-        if (init('action') == 'checkWiringPi') {
-            $prefix = logGetPrefix(""); // Get log prefix
-            $cmd = '/bin/bash '.__DIR__."/../scripts/checkWiringPi.sh | sed -e 's/^/".$prefix."/' >>".log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success(json_encode($status));
-        }
-
-        if (init('action') == 'installWiringPi') {
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/installWiringPi.sh >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success();
-        }
-
-        if (init('action') == 'checkPiGpio') {
-            $prefix = logGetPrefix(""); // Get log prefix
-            $cmd = '/bin/bash python '.__DIR__."/../scripts/checkPiGpio.py | sed -e 's/^/".$prefix."/' >>".log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success(json_encode($status));
-        }
-
-        if (init('action') == 'installPiGpio') {
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/installPiGpio.sh >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success();
-        }
-
-        if (init('action') == 'checkTTY') {
-            $zgPort = init('zgport');
-            $zgType = init('zgtype');
-            $zgGpioLib = init("zgGpioLib");
-
-            logSetConf('AbeilleConfig.log', true);
-            logMessage('info', 'Test de communication avec la Zigate; type='.$zgType.', port='.$zgPort.', GpioLib='.$zgGpioLib);
-
-            Abeille::pauseDaemons(1);
-
-            /* Checks port exists and is not already used */
-            $prefix = logGetPrefix(""); // Get log prefix
-            $cmdToExec = "checkTTY.sh ".$zgPort." ".$zgType." ".$zgGpioLib.' "'.$prefix.'"';
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/'.$cmdToExec." >>".log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-
-            /* Read Zigate FW version */
-            $version = 0; // FW version
-            if ($status == 0) {
-                $status = zgGetVersion($zgPort, $version);
-            }
-
             Abeille::pauseDaemons(0);
 
-            ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
-        }
-
-        if (init('action') == 'installTTY') {
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/installTTY.sh >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-            ajax::success();
-        }
-
-        /* Update FW but check parameters first, prior to shutdown daemon */
-        if (init('action') == 'updateFirmware') {
-            $zgType = init('zgtype'); // "PI" or "DIN"
-            $zgPort = init('zgport');
-            $zgGpioLib = init('zgGpioLib');
-            $zgFwFile = init('fwfile');
-            $erasePdm = init('erasePdm');
-            $zgId = init('zgId');
-
-            logSetConf('AbeilleConfig.log', true);
-            logMessage('debug', 'updateFirmware('.$zgType.', '.$zgFwFile.', '.$zgGpioLib.', '.$zgPort.')');
-
-            if ($zgType == "PI")
-                $script = "updateFirmware.sh";
-            else
-                $script = "updateFirmwareDIN.sh";
-
-            logMessage('debug', 'Checking parameters');
-            $cmdToExec = $script." check ".$zgPort." ".$zgGpioLib;
-            $cmd = '/bin/bash '.__DIR__.'/../scripts/'.$cmdToExec.' >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd, $out, $status);
-
-            $version = 0; // FW version
-            if ($status == 0) {
-                Abeille::pauseDaemons(1);
-
-                /* Updating FW and reset Zigate */
-                $cmdToExec = $script." flash ".$zgPort." ".$zgGpioLib." ".$zgFwFile;
-                $cmd = '/bin/bash '.__DIR__.'/../scripts/'.$cmdToExec.' >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-                exec($cmd, $out, $status);
-
-                /* Reading FW version */
-                // Tcharp38 note: removed this
-                // When restarting Zigate, several messages exchanges before being able to ask for version
-                // To be revisited
-                // if ($status == 0) {
-                //     $status = zgGetVersion($zgPort, $version);
-                // }
-
-                Abeille::pauseDaemons(0);
-
-                if ($erasePdm) {
-                    logMessage('info', 'Effacement de la PDM');
-                    if (sendToCmd('TempoCmdAbeille'.$zgId.'/0000/ErasePersistentData&time='.(time()+2), 'ErasePersistentData') == false) {
-                        $status = -1;
-                        $error = "Can't send erase PDM request";
-                    }
+            if ($erasePdm) {
+                logMessage('info', 'Effacement de la PDM');
+                if (sendToCmd('TempoCmdAbeille' . $zgId . '/0000/ErasePersistentData&time=' . (time() + 2), 'ErasePersistentData') == false) {
+                    $status = -1;
+                    $error = "Can't send erase PDM request";
                 }
             }
-
-            ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
         }
 
-        if (init('action') == 'resetPiZigate') {
-            $prefix = logGetPrefix(""); // Get log prefix
-            $cmd = "/bin/bash ".__DIR__."/../scripts/resetPiZigate.sh | sed -e 's/^/".$prefix."/' >>".log::getPathToLog('AbeilleConfig.log')." 2>&1";
-            exec($cmd, $out, $status);
-            ajax::success();
-        }
+        ajax::success(json_encode(array('status' => $status, 'fw' => $version)));
+    }
 
-        /* Devloper mode: Switch GIT branch */
-        if (init('action') == 'switchBranch') {
-            $branch = init('branch');
-            $updateOnly = init('updateOnly'); // TODO: No longer required
+    if (init('action') == 'resetPiZigate') {
+        $prefix = logGetPrefix(""); // Get log prefix
+        $cmd = "/bin/bash " . __DIR__ . "/../scripts/resetPiZigate.sh | sed -e 's/^/" . $prefix . "/' >>" . log::getPathToLog('AbeilleConfig.log') . " 2>&1";
+        exec($cmd, $out, $status);
+        ajax::success();
+    }
 
-            logSetConf('AbeilleConfig.log', true);
+    /* Devloper mode: Switch GIT branch */
+    if (init('action') == 'switchBranch') {
+        $branch = init('branch');
+        $updateOnly = init('updateOnly'); // TODO: No longer required
 
-            $status = 0;
-            $prefix = logGetPrefix(""); // Get log prefix
+        logSetConf('AbeilleConfig.log', true);
 
-            /* Creating temp dir */
-            $tmp = __DIR__.'/../../tmp';
-            $doneFile = $tmp.'/switchBranch.done';
-            if (file_exists($tmp) == false)
-                mkdir($tmp);
-            else if (file_exists($doneFile))
-                unlink($doneFile); // Removing 'switchBranch.done' file
+        $status = 0;
+        $prefix = logGetPrefix(""); // Get log prefix
 
-            /* Creating a copy of 'switchBranch.sh' in 'tmp' */
-            $cmd = 'cd '.__DIR__.'/../scripts/; sudo cp -p switchBranch.sh ../../tmp/switchBranch.sh >>'.log::getPathToLog('AbeilleConfig.log').' 2>&1';
-            exec($cmd);
+        /* Creating temp dir */
+        $tmp = __DIR__ . '/../../tmp';
+        $doneFile = $tmp . '/switchBranch.done';
+        if (file_exists($tmp) == false)
+            mkdir($tmp);
+        else if (file_exists($doneFile))
+            unlink($doneFile); // Removing 'switchBranch.done' file
 
-            // logMessage('debug', 'Arret des démons');
-            // abeille::deamon_stop(); // Stopping daemon
-            Abeille::pauseDaemons(1);
+        /* Creating a copy of 'switchBranch.sh' in 'tmp' */
+        $cmd = 'cd ' . __DIR__ . '/../scripts/; sudo cp -p switchBranch.sh ../../tmp/switchBranch.sh >>' . log::getPathToLog('AbeilleConfig.log') . ' 2>&1';
+        exec($cmd);
 
-            $cmdToExec = "switchBranch.sh ".$branch.' "'.$prefix.'"';
-            // $cmd = 'nohup /bin/bash '.__DIR__.'/../../tmp/'.$cmdToExec." >>".log::getPathToLog('AbeilleConfig.log').' 2>&1 &';
-            $cmd = '/bin/bash '.__DIR__.'/../../tmp/'.$cmdToExec." >>".log::getPathToLog('AbeilleConfig.log').' 2>&1 &';
-            exec($cmd);
+        // logMessage('debug', 'Arret des démons');
+        // abeille::deamon_stop(); // Stopping daemon
+        Abeille::pauseDaemons(1);
 
-            // TODO: There is something to be revisited there
-            // switch done in backbround but daemons are restarted BEFORE switch ended.
-            // TODO: Wait for switch end ?
+        $cmdToExec = "switchBranch.sh " . $branch . ' "' . $prefix . '"';
+        // $cmd = 'nohup /bin/bash '.__DIR__.'/../../tmp/'.$cmdToExec." >>".log::getPathToLog('AbeilleConfig.log').' 2>&1 &';
+        $cmd = '/bin/bash ' . __DIR__ . '/../../tmp/' . $cmdToExec . " >>" . log::getPathToLog('AbeilleConfig.log') . ' 2>&1 &';
+        exec($cmd);
 
-            Abeille::pauseDaemons(0);
+        // TODO: There is something to be revisited there
+        // switch done in backbround but daemons are restarted BEFORE switch ended.
+        // TODO: Wait for switch end ?
 
-            /* Note: Returning immediately but switch not completed yet. Anyway server side code
+        Abeille::pauseDaemons(0);
+
+        /* Note: Returning immediately but switch not completed yet. Anyway server side code
             might be completely different after switch */
-            ajax::success(json_encode(array('status' => $status)));
-        }
+        ajax::success(json_encode(array('status' => $status)));
+    }
 
-        /* Developer feature: Remove equipment(s) listed by id in 'eqList', from Jeedom DB.
+    /* Developer feature: Remove equipment(s) listed by id in 'eqList', from Jeedom DB.
         Zigate is untouched.
         Returns: status=0/-1, errors=<error message(s)> */
-        if (init('action') == 'removeEqJeedom') {
-            $eqList = init('eqList');
+    if (init('action') == 'removeEqJeedom') {
+        $eqList = init('eqList');
 
-            $status = 0;
-            $errors = ""; // Error messages
-            foreach ($eqList as $eqId) {
-                /* Collecting required infos */
-                $eqLogic = eqLogic::byId($eqId);
-                if (!is_object($eqLogic)) {
-                    throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__).' '.$eqId);
-                }
-
-                /* Removing device from Jeedom DB */
-                $eqLogic->remove();
-            }
-
-            ajax::success(json_encode(array('status' => $status, 'errors' => $errors)));
-        }
-
-        /* Remove equipment(s) from zigbee listed by id in 'eqIdList'.
-           Returns: status=0/-1, errors=<error message(s)> */
-        if (init('action') == 'removeEqZigbee') {
-            $eqIdList = init('eqIdList');
-
-            $status = 0;
-            $errors = ""; // Error messages
-            $missingParentIEEE = false;
-            foreach ($eqIdList as $eqId) {
-                /* Collecting required infos (zgId, parentIEEE & deviceIEEE) */
-                $eqLogic = eqLogic::byId($eqId);
-                if (!is_object($eqLogic)) {
-                    throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__).' '.$eqId);
-                }
-                $eqLogicId = $eqLogic->getLogicalid();
-                $eqName = $eqLogic->getName();
-                list($eqNet, $eqAddr) = explode( "/", $eqLogicId);
-                $zgId = substr($eqNet, 7); // Extracting zigate id from network name (AbeilleX)
-                $eqIEEE = $eqLogic->getConfiguration('IEEE', '');
-                $parentIEEE = $eqLogic->getConfiguration('parentIEEE', '');
-                // Tcharp38: parentIEEE not required with 004C command
-                // if (($eqIEEE == "") || ($parentIEEE == "")) {
-                if (($eqIEEE == "")) {
-                        /* Can't do it. Missing info */
-                    $status = -1;
-                    if ($eqIEEE == "")
-                        $errors .= "L'équipement '".$eqName."' n'a pas d'adresse IEEE\n";
-                    else {
-                        $errors .= "L'équipement '".$eqName."' n'a pas l'adresse IEEE de son parent\n";
-                        $missingParentIEEE = true;
-                    }
-                    continue;
-                }
-
-                /* Sending msg to 'AbeilleCmd' */
-                if (sendToCmd('CmdAbeille'.$zgId.'/0000/LeaveRequest', "IEEE=".$eqIEEE) == false) {
-                    $status = -1;
-                    $errors = "Impossible d'envoyer la demande de quitter le réseau";
-                }
-            }
-
-            if ($missingParentIEEE)
-                $errors .= "Forcer l'interrogation du réseau pour fixer le problème.";
-            ajax::success(json_encode(array('status' => $status, 'errors' => $errors)));
-        }
-
-        /* Check plugin integrity. This assumes that "Abeille.md5" is present and up-to-date.
-           Returns: status; 0=OK, -1=no MD5, -2=checksum error */
-        if (init('action') == 'checkIntegrity') {
-            $status = checkIntegrity();
-            $error = "";
-            if ($status == -1)
-                $error = "No MD5 file";
-            else
-                $error = "Checksum error";
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        /* Cleanup plugin repository based on "Abeille.md5" listed files.
-           Returns: status; 0=OK, -1=ERROR */
-        if (init('action') == 'doPostUpdateCleanup') {
-            if (validMd5Exists() != 0) {
-                ajax::success(json_encode(array('status' => -1, 'error' => "No valid MD5 file")));
-            }
-            $status = doPostUpdateCleanup();
-            $error = "";
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        /* Monitor equipment with given ID.
-        Returns: status=0/-1, errors=<error message(s)> */
-        if (init('action') == 'monitor') {
-            $eqId = init('eqId');
-
-            logSetConf("AbeilleMonitor.log", true);
-            // logMessage("debug", "AbeilleDev.ajax: action==monitor, eqId=".$eqId);
-
-            $status = 0;
-            $error = "";
-
-            $curMonId = config::byKey('ab::monitorId', 'Abeille', false);
-            if ($eqId !== $curMonId) {
-                /* Saving ID of device to monitor */
-                config::save('ab::monitorId', $eqId, 'Abeille');
-
-                /* Need to start AbeilleMonitor if not already running
-                and restart cmd & parser.
-                WARNING: If cron is not running, any (re)start should be avoided. */
-                $conf = AbeilleTools::getParameters();
-                AbeilleTools::restartDaemons($conf, "AbeilleMonitor AbeilleParser AbeilleCmd");
-            }
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        /* Migrate device to another one. */
-        // * https://github.com/KiwiHC16/Abeille/issues/1771
-        // *
-        // * 1/ Changement logical Id
-        // * 2/ Remove zigbee reseau 1 zigbee
-        // * 3/ inclusion normale sur le reseau 2 zigbee
-        // *
-        // * Faire un bouton qui fait les etapes 1/ et 2 puis demander à l'utilisateur de faire l'étape 3
-        if (init('action') == 'migrate') {
-            $eqId = init('eqId');
-            $dstZgId = init('dstZgId');
-
-            $status = 0;
-            $error = "";
-
-            $eqLogic = Abeille::byId($eqId);
-            if (!is_object($eqLogic)) {
-                $status = -1;
-                $error = "Unknown eqId ".$eqId;
-            } else {
-                $ieee = $eqLogic->getConfiguration('IEEE', 'none');
-                if ($ieee == 'none') {
-                    $status = -1;
-                    $error = "Device ".$eqId." DOES NOT have IEEE address";
-                } else {
-                    list($net, $addr) = explode('/', $eqLogic->getLogicalId());
-                    $zgId = substr($net, 7); // AbeilleX => X
-
-                    // $newNet = "Abeille".$dstZgId;
-
-                    // Moving eq to new network
-                    // $eqLogic->setLogicalId($newNet.'/'.$addr);
-                    // $eqLogic->save();
-
-                    // Excluding device from current network
-                    // self::publishMosquitto($abQueues['xToCmd']['id'], priorityNeWokeUp, "Cmd".$newDestBee."/0000/Remove", "ParentAddressIEEE=".$IEEE."&ChildAddressIEEE=".$IEEE );
-                    /* Sending msg to 'AbeilleCmd' */
-                    $topic   = 'CmdAbeille'.$dstZgId.'/0000/setZgPermitMode';
-                    $payload = "mode=start";
-                    if (sendToCmd($topic, $payload) == false) {
-                        $errors = "Could not send msg to 'xToCmd': topic=".$topic;
-                        $status = -1;
-                    }
-                    if ($status == 0) {
-                        $topic   = 'CmdAbeille'.$zgId.'/0000/LeaveRequest';
-                        $payload = "IEEE=".$ieee."&Rejoin=00";
-                        if (sendToCmd($topic, $payload) == false) {
-                            $errors = "Could not send msg to 'xToCmd': topic=".$topic;
-                            $status = -1;
-                        }
-                    }
-
-                    // 3/ inclusion normale sur le reseau 2 zigbee
-                    // message::add("Abeille", "Je viens de préparer la migration de ".$eqLogic->getHumanName(). ". Veuillez faire maintenant son inclusion dans la zigate ".$dstZgId);
-                }
-            }
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        /*  */
-        if (init('action') == 'acceptNewZigate') {
-            $zgId = init('zgId');
-
-            $status = 0;
-            $error = "";
-
-            config::remove("ab::zgIeeeAddrOk".$zgId, 'Abeille');
-            config::remove("ab::zgIeeeAddr".$zgId, 'Abeille');
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        /**
-         * replaceEq()
-         *
-         * @param deadEqId: Id of the bee to be removed
-         * @param newEqId: Id of the bee which will replace the ghost and receive all informations
-         *
-         * https://github.com/KiwiHC16/Abeille/issues/1055
-         */
-        if (init('action') == 'replaceEq') {
-            $deadEqId = init('deadEqId');
-            $newEqId = init('newEqId');
-
-            $status = 0;
-            $error = "";
-
-            $deadEq = Abeille::byId($deadEqId);
-            if (!is_object($deadEq)) {
-                $error = "Equipement HS inconnu (id ".$deadId.")";
-                $status = -1;
-            }
-            if ($status == 0) {
-                $newEq = Abeille::byId($newEqId);
-                if (!is_object($newEq)) {
-                    $error = "Nouvel equipement inconnu (id ".$newId.")";
-                    $status = -1;
-                }
-            }
-
-            if ($status == 0) {
-                list($deadNet, $deadAddr) = explode('/', $deadEq->getLogicalId());
-                list($newNet, $newAddr) = explode('/', $newEq->getLogicalId());
-
-                $oldIeee = $deadEq->getConfiguration('IEEE', '');
-                if ($oldIeee != '') {
-                    log::add('Abeille', 'debug', 'Je retire '.$deadEq->getName().' de la zigate.');
-                    sendToCmd("Cmd".$deadNet."/0000/Remove", "ParentAddressIEEE=".$oldIeee."&ChildAddressIEEE=".$oldIeee);
-                }
-
-                // Collecting ieee & short addr from new device to assign them to old one
-                $newIeee = $newEq->getConfiguration('IEEE', '');
-                $deadEq->setConfiguration('IEEE', $newIeee);
-                $deadEq->setLogicalId($newEq->getLogicalId());
-
-                $newEq->remove();
-                $deadEq->save();
-            }
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
-        }
-
-        // Get 'eqLogic' content for given 'eqId'
-        if (init('action') == 'getEq') {
-            $eqId = init('eqId');
-
-            $status = 0;
-            $error = "";
-            $eq = [];
-
+        $status = 0;
+        $errors = ""; // Error messages
+        foreach ($eqList as $eqId) {
+            /* Collecting required infos */
             $eqLogic = eqLogic::byId($eqId);
             if (!is_object($eqLogic)) {
-                $error = "Equipement inconnu (id ".$eqId.")";
-                $status = -1;
-            } else {
-                $eq['id'] = $eqId;
-                $eq['name'] = $eqLogic->getName();
-                $eq['logicId'] = $eqLogic->getLogicalId();
-                list($eqNet, $eqAddr) = explode("/", $eq['logicId']);
-                $eq['zgId'] = substr($eqNet, 7);
-                $eq['zgType'] = config::byKey('ab::zgType'.$eq['zgId'], 'Abeille', '', 1);
-                $eq['zgChan'] = config::byKey('ab::zgChan'.$eq['zgId'], 'Abeille', '', 1);
-                $eq['addr'] = $eqAddr;
-                $eq['defaultEp'] = $eqLogic->getConfiguration('mainEP', '');
-                $eq['batteryType'] = $eqLogic->getConfiguration('battery_type', '');
-
-                $sig = $eqLogic->getConfiguration('ab::signature', []);
-                $eq['zbModel'] = isset($sig['modelId']) ? $sig['modelId'] : '';
-                $eq['zbManuf'] = isset($sig['manufId']) ? $sig['manufId'] : '';
-
-                $model = $eqLogic->getConfiguration('ab::eqModel', []);
-                $eq['modelName'] = isset($model['id']) ? $model['id'] : '';
-                $eq['modelSource'] = isset($model['location']) ? $model['location'] : 'Abeille';
-                $eq['modelType'] = isset($model['type']) ? $model['type'] : '';
-
-                $eq['zigbee'] = $eqLogic->getConfiguration('ab::zigbee', []);
-
-                $jCmds = Cmd::byEqLogicId($eqId);
-                $eq['cmds'] = [];
-                foreach ($jCmds as $cmdLogic) {
-                    $cmdId = $cmdLogic->getId();
-                    $cmdLogicId = $cmdLogic->getLogicalId('');
-                    if ($cmdLogic->getType() == 'info')
-                        $cmdVal = $cmdLogic->execCmd();
-                    else
-                        $cmdVal = '';
-                    $eq['cmds'][$cmdLogicId] = array(
-                        'id' => $cmdId,
-                        'val' => $cmdVal
-                    );
-                }
+                throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqId);
             }
 
-            ajax::success(json_encode(array('status' => $status, 'error' => $error, 'eq' => $eq)));
+            /* Removing device from Jeedom DB */
+            $eqLogic->remove();
         }
 
-        // Retrieves all informations suitable to fill health page
-        if (init('action') == 'getHealthDatas') {
-            $status = 0;
-            $error = "";
-            $eq = [];
+        ajax::success(json_encode(array('status' => $status, 'errors' => $errors)));
+    }
 
-            $eqLogics = eqLogic::byType('Abeille');
-            foreach ($eqLogics as $eqLogic) {
-                $eqLogicId = $eqLogic->getLogicalId();
-                list($eqNet, $eqAddr) = explode("/", $eqLogicId);
+    /* Remove equipment(s) from zigbee listed by id in 'eqIdList'.
+           Returns: status=0/-1, errors=<error message(s)> */
+    if (init('action') == 'removeEqZigbee') {
+        $eqIdList = init('eqIdList');
 
-                $e = [];
-                $e['link'] = $eqLogic->getLinkToConfiguration();
-                $e['hName'] = $eqLogic->getHumanName(true);
-                $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
-                $type = isset($eqModel['type']) ? $eqModel['type'] : '?';
-                $e['type'] = $type;
-                $e['ieee'] = $eqLogic->getConfiguration('IEEE', '');
-                $e['isEnabled'] = $eqLogic->getIsEnable();
-                $e['timeout'] = $eqLogic->getStatus('timeout');
-                $e['lastComm'] = $eqLogic->getStatus('lastCommunication');
-                if (substr($eqAddr, 0, 2) == "rc") // Remote control ?
-                    $e['since'] = '-';
-                else
-                    $e['since'] = floor((time() - strtotime($e['lastComm'])) / 3600);
-
-                // Last LQI
-                if ($eqAddr == "0000")
-                    $lastLqi = "-";
+        $status = 0;
+        $errors = ""; // Error messages
+        $missingParentIEEE = false;
+        foreach ($eqIdList as $eqId) {
+            /* Collecting required infos (zgId, parentIEEE & deviceIEEE) */
+            $eqLogic = eqLogic::byId($eqId);
+            if (!is_object($eqLogic)) {
+                throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqId);
+            }
+            $eqLogicId = $eqLogic->getLogicalid();
+            $eqName = $eqLogic->getName();
+            list($eqNet, $eqAddr) = explode("/", $eqLogicId);
+            $zgId = substr($eqNet, 7); // Extracting zigate id from network name (AbeilleX)
+            $eqIEEE = $eqLogic->getConfiguration('IEEE', '');
+            $parentIEEE = $eqLogic->getConfiguration('parentIEEE', '');
+            // Tcharp38: parentIEEE not required with 004C command
+            // if (($eqIEEE == "") || ($parentIEEE == "")) {
+            if (($eqIEEE == "")) {
+                /* Can't do it. Missing info */
+                $status = -1;
+                if ($eqIEEE == "")
+                    $errors .= "L'équipement '" . $eqName . "' n'a pas d'adresse IEEE\n";
                 else {
-                    $lqiCmd = $eqLogic->getCmd('info', 'Link-Quality');
-                    if (is_object($lqiCmd))
-                        $lastLqi = $lqiCmd->execCmd();
-                    else
-                        $lastLqi = "?";
+                    $errors .= "L'équipement '" . $eqName . "' n'a pas l'adresse IEEE de son parent\n";
+                    $missingParentIEEE = true;
                 }
-                $e['lastLqi'] = $lastLqi;
-
-                // Last battery status
-                $bat = $eqLogic->getStatus('battery', '');
-                if ($bat == '')
-                    $bat = '-';
-                else
-                    $bat = $bat.'%';
-                $e['lastBat'] = $bat;
-
-                if (!isset($eq[$eqNet]))
-                    $eq[$eqNet] = [];
-                if (!isset($eq[$eqNet][$eqAddr]))
-                    $eq[$eqNet][$eqAddr] = $e;
+                continue;
             }
 
-            ajax::success(json_encode(array('status' => $status, 'error' => $error, 'eq' => $eq)));
-        } // End getHealthDatas
-
-        // Read 'ab::settings' content
-        // Params: eqId = Equipment Jeedom ID
-        if (init('action') == 'getSettings') {
-            $status = 0;
-            $error = "";
-
-            $eqId = init('eqId');
-            $eqLogic = Abeille::byId($eqId);
-            $settings = [];
-            if (!is_object($eqLogic)) {
-                $error = "Invalid device ID ".$eqId;
+            /* Sending msg to 'AbeilleCmd' */
+            if (sendToCmd('CmdAbeille' . $zgId . '/0000/LeaveRequest', "IEEE=" . $eqIEEE) == false) {
                 $status = -1;
-            } else
-                $settings = $eqLogic->getConfiguration('ab::settings', []);
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error, 'settings' => $settings)));
+                $errors = "Impossible d'envoyer la demande de quitter le réseau";
+            }
         }
 
-        // Change eqLogic 'ab::settings' content
-        // Param: eqId = Equipment Jeedom ID
-        // Param: settings = associative array of settings to change
-        if (init('action') == 'saveSettings') {
-            $status = 0;
-            $error = "";
+        if ($missingParentIEEE)
+            $errors .= "Forcer l'interrogation du réseau pour fixer le problème.";
+        ajax::success(json_encode(array('status' => $status, 'errors' => $errors)));
+    }
 
-            $eqId = init('eqId');
-            $newSettings = init('settings');
-            $newSettings = json_decode($newSettings, true);
+    /* Check plugin integrity. This assumes that "Abeille.md5" is present and up-to-date.
+           Returns: status; 0=OK, -1=no MD5, -2=checksum error */
+    if (init('action') == 'checkIntegrity') {
+        $status = checkIntegrity();
+        $error = "";
+        if ($status == -1)
+            $error = "No MD5 file";
+        else
+            $error = "Checksum error";
 
-            $eqLogic = Abeille::byId($eqId);
-            if (!is_object($eqLogic)) {
-                $error = "Invalid device ID ".$eqId;
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    /* Cleanup plugin repository based on "Abeille.md5" listed files.
+           Returns: status; 0=OK, -1=ERROR */
+    if (init('action') == 'doPostUpdateCleanup') {
+        if (validMd5Exists() != 0) {
+            ajax::success(json_encode(array('status' => -1, 'error' => "No valid MD5 file")));
+        }
+        $status = doPostUpdateCleanup();
+        $error = "";
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    /* Monitor equipment with given ID.
+        Returns: status=0/-1, errors=<error message(s)> */
+    if (init('action') == 'monitor') {
+        $eqId = init('eqId');
+
+        logSetConf("AbeilleMonitor.log", true);
+        // logMessage("debug", "AbeilleDev.ajax: action==monitor, eqId=".$eqId);
+
+        $status = 0;
+        $error = "";
+
+        $curMonId = config::byKey('ab::monitorId', 'Abeille', false);
+        if ($eqId !== $curMonId) {
+            /* Saving ID of device to monitor */
+            config::save('ab::monitorId', $eqId, 'Abeille');
+
+            /* Need to start AbeilleMonitor if not already running
+                and restart cmd & parser.
+                WARNING: If cron is not running, any (re)start should be avoided. */
+            $conf = AbeilleTools::getParameters();
+            AbeilleTools::restartDaemons($conf, "AbeilleMonitor AbeilleParser AbeilleCmd");
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    /* Migrate device to another one. */
+    // * https://github.com/KiwiHC16/Abeille/issues/1771
+    // *
+    // * 1/ Changement logical Id
+    // * 2/ Remove zigbee reseau 1 zigbee
+    // * 3/ inclusion normale sur le reseau 2 zigbee
+    // *
+    // * Faire un bouton qui fait les etapes 1/ et 2 puis demander à l'utilisateur de faire l'étape 3
+    if (init('action') == 'migrate') {
+        $eqId = init('eqId');
+        $dstZgId = init('dstZgId');
+
+        $status = 0;
+        $error = "";
+
+        $eqLogic = Abeille::byId($eqId);
+        if (!is_object($eqLogic)) {
+            $status = -1;
+            $error = "Unknown eqId " . $eqId;
+        } else {
+            $ieee = $eqLogic->getConfiguration('IEEE', 'none');
+            if ($ieee == 'none') {
                 $status = -1;
+                $error = "Device " . $eqId . " DOES NOT have IEEE address";
             } else {
-                $settings = $eqLogic->getConfiguration('ab::settings', []);
-                foreach ($newSettings as $setKey => $setVal) {
-                    $settings[$setKey] = $setVal;
-                    logDebug('  settings['.$setKey.']='.$setVal);
+                list($net, $addr) = explode('/', $eqLogic->getLogicalId());
+                $zgId = substr($net, 7); // AbeilleX => X
+
+                // $newNet = "Abeille".$dstZgId;
+
+                // Moving eq to new network
+                // $eqLogic->setLogicalId($newNet.'/'.$addr);
+                // $eqLogic->save();
+
+                // Excluding device from current network
+                // self::publishMosquitto($abQueues['xToCmd']['id'], priorityNeWokeUp, "Cmd".$newDestBee."/0000/Remove", "ParentAddressIEEE=".$IEEE."&ChildAddressIEEE=".$IEEE );
+                /* Sending msg to 'AbeilleCmd' */
+                $topic   = 'CmdAbeille' . $dstZgId . '/0000/setZgPermitMode';
+                $payload = "mode=start";
+                if (sendToCmd($topic, $payload) == false) {
+                    $errors = "Could not send msg to 'xToCmd': topic=" . $topic;
+                    $status = -1;
                 }
-                $eqLogic->setConfiguration('ab::settings', $settings);
-                $eqLogic->save();
-            }
+                if ($status == 0) {
+                    $topic   = 'CmdAbeille' . $zgId . '/0000/LeaveRequest';
+                    $payload = "IEEE=" . $ieee . "&Rejoin=00";
+                    if (sendToCmd($topic, $payload) == false) {
+                        $errors = "Could not send msg to 'xToCmd': topic=" . $topic;
+                        $status = -1;
+                    }
+                }
 
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+                // 3/ inclusion normale sur le reseau 2 zigbee
+                // message::add("Abeille", "Je viens de préparer la migration de ".$eqLogic->getHumanName(). ". Veuillez faire maintenant son inclusion dans la zigate ".$dstZgId);
+            }
         }
 
-        // Change 'config' DB content based on given keys
-        if (init('action') == 'saveConfig') {
-            $status = 0;
-            $error = "";
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
 
-            $config = init('config');
-            logDebug('config='.$config);
+    /*  */
+    if (init('action') == 'acceptNewZigate') {
+        $zgId = init('zgId');
 
-            $config = json_decode($config, true);
-            foreach ($config as $key => $value) {
-                config::save($key, $value, 'Abeille');
+        $status = 0;
+        $error = "";
+
+        config::remove("ab::zgIeeeAddrOk" . $zgId, 'Abeille');
+        config::remove("ab::zgIeeeAddr" . $zgId, 'Abeille');
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    /**
+     * replaceEq()
+     *
+     * @param deadEqId: Id of the bee to be removed
+     * @param newEqId: Id of the bee which will replace the ghost and receive all informations
+     *
+     * https://github.com/KiwiHC16/Abeille/issues/1055
+     */
+    if (init('action') == 'replaceEq') {
+        $deadEqId = init('deadEqId');
+        $newEqId = init('newEqId');
+
+        $status = 0;
+        $error = "";
+
+        $deadEq = Abeille::byId($deadEqId);
+        if (!is_object($deadEq)) {
+            $error = "Equipement HS inconnu (id " . $deadId . ")";
+            $status = -1;
+        }
+        if ($status == 0) {
+            $newEq = Abeille::byId($newEqId);
+            if (!is_object($newEq)) {
+                $error = "Nouvel equipement inconnu (id " . $newId . ")";
+                $status = -1;
             }
-
-            ajax::success(json_encode(array('status' => $status, 'error' => $error)));
         }
 
-        /* WARNING: ajax::error DOES NOT trig 'error' callback on client side.
+        if ($status == 0) {
+            list($deadNet, $deadAddr) = explode('/', $deadEq->getLogicalId());
+            list($newNet, $newAddr) = explode('/', $newEq->getLogicalId());
+
+            $oldIeee = $deadEq->getConfiguration('IEEE', '');
+            if ($oldIeee != '') {
+                log::add('Abeille', 'debug', 'Je retire ' . $deadEq->getName() . ' de la zigate.');
+                sendToCmd("Cmd" . $deadNet . "/0000/Remove", "ParentAddressIEEE=" . $oldIeee . "&ChildAddressIEEE=" . $oldIeee);
+            }
+
+            // Collecting ieee & short addr from new device to assign them to old one
+            $newIeee = $newEq->getConfiguration('IEEE', '');
+            $deadEq->setConfiguration('IEEE', $newIeee);
+            $deadEq->setLogicalId($newEq->getLogicalId());
+
+            $newEq->remove();
+            $deadEq->save();
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    // Get 'eqLogic' content for given 'eqId'
+    if (init('action') == 'getEq') {
+        $eqId = init('eqId');
+
+        $status = 0;
+        $error = "";
+        $eq = [];
+
+        $eqLogic = eqLogic::byId($eqId);
+        if (!is_object($eqLogic)) {
+            $error = "Equipement inconnu (id " . $eqId . ")";
+            $status = -1;
+        } else {
+            $eq['id'] = $eqId;
+            $eq['name'] = $eqLogic->getName();
+            $eq['logicId'] = $eqLogic->getLogicalId();
+            list($eqNet, $eqAddr) = explode("/", $eq['logicId']);
+            $eq['zgId'] = substr($eqNet, 7);
+            $eq['zgType'] = config::byKey('ab::zgType' . $eq['zgId'], 'Abeille', '', 1);
+            $eq['zgChan'] = config::byKey('ab::zgChan' . $eq['zgId'], 'Abeille', '', 1);
+            $eq['addr'] = $eqAddr;
+            $eq['defaultEp'] = $eqLogic->getConfiguration('mainEP', '');
+            $eq['batteryType'] = $eqLogic->getConfiguration('battery_type', '');
+
+            $sig = $eqLogic->getConfiguration('ab::signature', []);
+            $eq['zbModel'] = isset($sig['modelId']) ? $sig['modelId'] : '';
+            $eq['zbManuf'] = isset($sig['manufId']) ? $sig['manufId'] : '';
+
+            $model = $eqLogic->getConfiguration('ab::eqModel', []);
+            $eq['modelName'] = isset($model['id']) ? $model['id'] : '';
+            $eq['modelSource'] = isset($model['location']) ? $model['location'] : 'Abeille';
+            $eq['modelType'] = isset($model['type']) ? $model['type'] : '';
+
+            // Ajout JB Romain 16/08/2023 - Indique si l'utilisateur a forcé le modèle
+            $eq['isManualModel'] = $eqLogic->getConfiguration('ab::isManualModel', false);
+
+            $eq['zigbee'] = $eqLogic->getConfiguration('ab::zigbee', []);
+
+            $jCmds = Cmd::byEqLogicId($eqId);
+            $eq['cmds'] = [];
+            foreach ($jCmds as $cmdLogic) {
+                $cmdId = $cmdLogic->getId();
+                $cmdLogicId = $cmdLogic->getLogicalId('');
+                if ($cmdLogic->getType() == 'info')
+                    $cmdVal = $cmdLogic->execCmd();
+                else
+                    $cmdVal = '';
+                $eq['cmds'][$cmdLogicId] = array(
+                    'id' => $cmdId,
+                    'val' => $cmdVal
+                );
+            }
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error, 'eq' => $eq)));
+    }
+
+    // Retrieves all informations suitable to fill health page
+    if (init('action') == 'getHealthDatas') {
+        $status = 0;
+        $error = "";
+        $eq = [];
+
+        $eqLogics = eqLogic::byType('Abeille');
+        foreach ($eqLogics as $eqLogic) {
+            $eqLogicId = $eqLogic->getLogicalId();
+            list($eqNet, $eqAddr) = explode("/", $eqLogicId);
+
+            $e = [];
+            $e['link'] = $eqLogic->getLinkToConfiguration();
+            $e['hName'] = $eqLogic->getHumanName(true);
+            $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
+            $type = isset($eqModel['type']) ? $eqModel['type'] : '?';
+            $e['type'] = $type;
+            $e['ieee'] = $eqLogic->getConfiguration('IEEE', '');
+            $e['isEnabled'] = $eqLogic->getIsEnable();
+            $e['timeout'] = $eqLogic->getStatus('timeout');
+            $e['lastComm'] = $eqLogic->getStatus('lastCommunication');
+            if (substr($eqAddr, 0, 2) == "rc") // Remote control ?
+                $e['since'] = '-';
+            else
+                $e['since'] = floor((time() - strtotime($e['lastComm'])) / 3600);
+
+            // Last LQI
+            if ($eqAddr == "0000")
+                $lastLqi = "-";
+            else {
+                $lqiCmd = $eqLogic->getCmd('info', 'Link-Quality');
+                if (is_object($lqiCmd))
+                    $lastLqi = $lqiCmd->execCmd();
+                else
+                    $lastLqi = "?";
+            }
+            $e['lastLqi'] = $lastLqi;
+
+            // Last battery status
+            $bat = $eqLogic->getStatus('battery', '');
+            if ($bat == '')
+                $bat = '-';
+            else
+                $bat = $bat . '%';
+            $e['lastBat'] = $bat;
+
+            if (!isset($eq[$eqNet]))
+                $eq[$eqNet] = [];
+            if (!isset($eq[$eqNet][$eqAddr]))
+                $eq[$eqNet][$eqAddr] = $e;
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error, 'eq' => $eq)));
+    } // End getHealthDatas
+
+    // Read 'ab::settings' content
+    // Params: eqId = Equipment Jeedom ID
+    if (init('action') == 'getSettings') {
+        $status = 0;
+        $error = "";
+
+        $eqId = init('eqId');
+        $eqLogic = Abeille::byId($eqId);
+        $settings = [];
+        if (!is_object($eqLogic)) {
+            $error = "Invalid device ID " . $eqId;
+            $status = -1;
+        } else
+            $settings = $eqLogic->getConfiguration('ab::settings', []);
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error, 'settings' => $settings)));
+    }
+
+    // Change eqLogic 'ab::settings' content
+    // Param: eqId = Equipment Jeedom ID
+    // Param: settings = associative array of settings to change
+    if (init('action') == 'saveSettings') {
+        $status = 0;
+        $error = "";
+
+        $eqId = init('eqId');
+        $newSettings = init('settings');
+        $newSettings = json_decode($newSettings, true);
+
+        $eqLogic = Abeille::byId($eqId);
+        if (!is_object($eqLogic)) {
+            $error = "Invalid device ID " . $eqId;
+            $status = -1;
+        } else {
+            $settings = $eqLogic->getConfiguration('ab::settings', []);
+            foreach ($newSettings as $setKey => $setVal) {
+                $settings[$setKey] = $setVal;
+                logDebug('  settings[' . $setKey . ']=' . $setVal);
+            }
+            $eqLogic->setConfiguration('ab::settings', $settings);
+            $eqLogic->save();
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    // Change 'config' DB content based on given keys
+    if (init('action') == 'saveConfig') {
+        $status = 0;
+        $error = "";
+
+        $config = init('config');
+        logDebug('config=' . $config);
+
+        $config = json_decode($config, true);
+        foreach ($config as $key => $value) {
+            config::save($key, $value, 'Abeille');
+        }
+
+        ajax::success(json_encode(array('status' => $status, 'error' => $error)));
+    }
+
+    /* WARNING: ajax::error DOES NOT trig 'error' callback on client side.
             Instead 'success' callback is used. This means that
             - take care of error code returned
             - convert to JSON since dataType is set to 'json' */
-        $error = "La méthode '".init('action')."' n'existe pas dans 'Abeille.ajax.php'";
-        throw new Exception($error, -1);
-    } catch (Exception $e) {
-        /* Catch exeption */
-        ajax::error(json_encode(array('status' => $e->getCode(), 'error' => $e->getMessage())));
-    }
-?>
+    $error = "La méthode '" . init('action') . "' n'existe pas dans 'Abeille.ajax.php'";
+    throw new Exception($error, -1);
+} catch (Exception $e) {
+    /* Catch exeption */
+    ajax::error(json_encode(array('status' => $e->getCode(), 'error' => $e->getMessage())));
+}

--- a/core/ajax/AbeilleModelChange.ajax.php
+++ b/core/ajax/AbeilleModelChange.ajax.php
@@ -1,0 +1,249 @@
+<?php
+
+/* This file is part of Plugin abeille for jeedom.
+*
+* Plugin abeille for jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Plugin abeille for jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Plugin abeille for jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Ce fichier gère le changement de modèle d'un équipement à l'initiative de l'utilisateur.
+ * - Permet d'afficher des JSON existants
+ * - Enregistre le choix de l'utilisateur
+ * 
+ * @author JB Romain 16/08/2023
+ */
+
+require_once __DIR__ . '/../config/Abeille.config.php'; // dbgFile constant + queues
+if (file_exists(dbgFile)) {
+    /* Dev mode: enabling PHP errors logging */
+    error_reporting(E_ALL);
+    ini_set('error_log', __DIR__ . '/../../../../log/AbeillePHP.log');
+    ini_set('log_errors', 'On');
+}
+
+// Vérification d'authentification
+require_once __DIR__ . '/../../../../core/php/core.inc.php';
+include_file('core', 'authentification', 'php');
+if (!isConnect('admin')) {
+    throw new Exception('401 Unauthorized');
+}
+
+define('devicesDir', __DIR__ . '/../config/devices/'); // Abeille's supported devices
+define('devicesLocalDir', __DIR__ . '/../config/devices_local/'); // Unsupported/user devices
+
+// Exécution de l'action demandée
+$action = $_POST['action'];
+
+if (function_exists($action)) {
+    $action();
+} else {
+    die("L'action demandée n'existe pas");
+}
+
+/**
+ * Retourne en JSON la liste des modèles possibles (connus d'abeille).
+ * Inclut les modèles d'origine et les modèles locaux s'il en existe.
+ */
+function getModelChoiceList()
+{
+    // On permet le choix des modèles locaux et des modèles officiels
+    // Tableau associatif modelID => model data
+    $list = getDevicesList("local");
+    $list = array_merge($list, getDevicesList("Abeille"));
+
+    // On récupère le modèle actuel de l'équipement (s'il en a un)
+    $eqId = (int) $_POST['eqId'];
+    $eqLogic = eqLogic::byId($eqId);
+    if (!is_object($eqLogic)) {
+        throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqId);
+    }
+    $currentModel = $eqLogic->getConfiguration('ab::eqModel', null);
+    $currentModelID = null;
+    if ($currentModel != null && isset($currentModel['id'])) {
+        $currentModelID = $currentModel['id'];
+    }
+
+    // Si on a un modèle actuel, on pourra pré-remplir l'IHM: on passe l'info
+    if ($currentModelID != null && isset($list[$currentModelID])) {
+        $list[$currentModelID]['isCurrent'] = true;
+    }
+
+    // On envoie la liste
+    die(json_encode($list));
+}
+
+/**
+ * Enregistre le choix de l'utilisateur: change le modèle de l'équipement, et 
+ * le force en 'manuel' afin que le modèle ne soit plus modifié automatiquement
+ * à partir de la signature zigbee à la prochaine annonce de l'équipement.
+ */
+function setModelToDevice()
+{
+    // Récupération de l'équipement
+    $eqId = (int) $_POST['eqId'];
+    $eqLogic = eqLogic::byId($eqId);
+    if (!is_object($eqLogic)) {
+        throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqId);
+    }
+
+    // Récupération du modèle choisi, sous la forme "blabla (Abeille/id.json)" ou "blabla (local/id.json)"
+    $strSaisie = $_POST['modelChoice'];
+
+    // Extraction du chemin réel du modèle JSON à utiliser
+    $tmpPos = strrpos($strSaisie, ' (');
+    if ($tmpPos === false) {
+        throw new Exception(__('Saisie incorrecte', __FILE__) . ' ' . $eqId);
+    }
+
+    $tmpModelPath = mb_substr($strSaisie, $tmpPos + 2); // "Abeille/id.json)" 
+    $tmpModelPath = mb_substr($tmpModelPath, 0, mb_strlen($tmpModelPath) - 1); // "Abeille/id.json"
+
+    $tmpNomModel = explode("/", $tmpModelPath);
+    if (!is_array($tmpNomModel) || sizeof($tmpNomModel) != 2) {
+        throw new Exception(__('Saisie incorrecte', __FILE__) . ' ' . $eqId);
+    }
+    $source = $tmpNomModel[0]; // Abeille ou local
+    $json = pathinfo(basename($tmpNomModel[1]), PATHINFO_FILENAME); // retire le .json
+
+    $modelPath = '';
+    if ($source == 'Abeille') {
+        $modelPath = devicesDir . $json . '/' . $json . '.json';
+    } else {
+        $modelPath = devicesLocalDir . $json . '/' . $json . '.json';
+        $source = 'local'; // normalement c'est déjà le cas
+    }
+
+    // On vérifie que le fichier modèle existe (sécurité ultime) et on le charge
+    if (!is_readable($modelPath)) {
+        throw new Exception(__('Saisie incorrecte - Fichier modèle introuvable', __FILE__) . ' ' . $eqId);
+    }
+    $jsonModelData = json_decode(file_get_contents($modelPath), true);
+    if (!isset($jsonModelData[$json]['type'])) {
+        // Bizarre, mais il y a peut-être des vieux json mal remplis
+        $libelleType = '';
+    } else {
+        $libelleType = $jsonModelData[$json]['type'];
+    }
+
+    // Enregistrement de la nouvelle configuration
+    $eqModelInfos = array(
+        'id' => $json, // ID du json
+        'location' => $source, // Abeille ou local
+        'type' => $libelleType,
+        'lastUpdate' => time() // Store last update from model
+    );
+    $eqLogic->setConfiguration('ab::eqModel', $eqModelInfos);
+
+    // Le modèle a été choisi manuellement, il ne sera pas écrasé en cas de ré-annonce de l'équipement
+    $eqLogic->setConfiguration('ab::isManualModel', true);
+
+    $eqLogic->save();
+
+    message::add("Abeille", date('d/m/Y H:i:s') . " > Modèle enregistré. L'équipement va maintenant être reconfiguré...", '');
+    die("true");
+
+    // (L'IHM enverra une deuxième requête ajax pour reconfigurer l'équipement à partir du nouveau modèle)
+}
+
+/**
+ * Rétablit le fonctionnement normal de la sélection de modèle pour un équipement.
+ * (= le modèle pourra à nouveau être détecté par Abeille à la prochaine annonce de l'équipement)
+ */
+function disableManualModelForDevice()
+{
+    // Récupération de l'équipement
+    $eqId = (int) $_POST['eqId'];
+    $eqLogic = eqLogic::byId($eqId);
+    if (!is_object($eqLogic)) {
+        throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqId);
+    }
+
+    // On restaure le fonctionnement normal
+    $eqLogic->setConfiguration('ab::isManualModel', false);
+    $eqLogic->save();
+
+    message::add("Abeille", date('d/m/Y H:i:s') . " > Choix automatique du modèle réactivé pour cet équipement. Vous pouvez maintenant le Mettre à jour pour le re-configurer.", '');
+
+
+    die("true");
+}
+
+
+
+/** Code repris de .tools\gen_devices_list.php  */
+
+
+/* Get list of supported devices ($from="Abeille"), or user/custom ones ($from="local")
+        Returns: Associative array; $devicesList[$identifier] = array(), or false if error */
+function getDevicesList($from = "Abeille")
+{
+    $devicesList = [];
+
+    if ($from == "Abeille")
+        $rootDir = devicesDir;
+    else if ($from == "local")
+        $rootDir = devicesLocalDir;
+    else {
+        echo ("ERROR: Emplacement JSON '" . $from . "' invalide\n");
+        return false;
+    }
+
+    $dh = opendir($rootDir);
+    if ($dh === false) {
+        echo ('ERROR: getDevicesList(): opendir(' . $rootDir . ')\n');
+        return false;
+    }
+    while (($dirEntry = readdir($dh)) !== false) {
+        /* Ignoring some entries */
+        if (in_array($dirEntry, array(".", "..")))
+            continue;
+        $fullPath = $rootDir . $dirEntry;
+        if (!is_dir($fullPath))
+            continue;
+
+        $fullPath = $rootDir . $dirEntry . '/' . $dirEntry . ".json";
+        if (!file_exists($fullPath))
+            continue; // No local JSON model. Maybe just an auto-discovery ?
+
+        $dev = array(
+            'jsonId' => $dirEntry,
+            'jsonLocation' => $from
+        );
+
+        /* Check if config is compliant with other device identification */
+        $content = file_get_contents($fullPath);
+        $devConf = json_decode($content, true);
+        $devConf = $devConf[$dirEntry]; // Removing top key
+        $dev['manufacturer'] = isset($devConf['manufacturer']) ? $devConf['manufacturer'] : '';
+        $dev['model'] = isset($devConf['model']) ? $devConf['model'] : '';
+        $dev['type'] = $devConf['type'];
+        $dev['icon'] = $devConf['configuration']['icon'];
+        $devicesList[$dirEntry] = $dev;
+
+        if (isset($devConf['alternateIds'])) {
+            $idList = explode(',', $devConf['alternateIds']);
+            foreach ($idList as $id) {
+                echo ("getDevicesList(): Alternate ID '" . $id . "' for '" . $dirEntry . "'\n");
+                $dev = array(
+                    'jsonId' => $dirEntry,
+                    'jsonLocation' => $from
+                );
+                $devicesList[$id] = $dev;
+            }
+        }
+    }
+    closedir($dh);
+
+    return $devicesList;
+}

--- a/core/class/Abeille.class.php
+++ b/core/class/Abeille.class.php
@@ -1,5 +1,5 @@
 <?php
-    /* This file is part of Jeedom.
+/* This file is part of Jeedom.
     *
     * Jeedom is free software: you can redistribute it and/or modify
     * it under the terms of the GNU General Public License as published by
@@ -15,24 +15,25 @@
     * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
     */
 
-    include_once __DIR__.'/../config/Abeille.config.php';
+include_once __DIR__ . '/../config/Abeille.config.php';
 
-    /* Developers debug features */
-    if (file_exists(dbgFile)) {
-        // include_once dbgFile;
-        /* Dev mode: enabling PHP errors logging */
-        error_reporting(E_ALL);
-        ini_set('error_log', __DIR__.'/../../../../log/AbeillePHP.log');
-        ini_set('log_errors', 'On');
-    }
+/* Developers debug features */
+if (file_exists(dbgFile)) {
+    // include_once dbgFile;
+    /* Dev mode: enabling PHP errors logging */
+    error_reporting(E_ALL);
+    ini_set('error_log', __DIR__ . '/../../../../log/AbeillePHP.log');
+    ini_set('log_errors', 'On');
+}
 
-    include_once __DIR__.'/../../../../core/php/core.inc.php';
-    include_once __DIR__.'/AbeilleTools.class.php';
-    include_once __DIR__.'/AbeilleCmd.class.php';
-    include_once __DIR__.'/../../plugin_info/install.php'; // updateConfigDB()
-    include_once __DIR__.'/../php/AbeilleLog.php'; // logGetPluginLevel()
+include_once __DIR__ . '/../../../../core/php/core.inc.php';
+include_once __DIR__ . '/AbeilleTools.class.php';
+include_once __DIR__ . '/AbeilleCmd.class.php';
+include_once __DIR__ . '/../../plugin_info/install.php'; // updateConfigDB()
+include_once __DIR__ . '/../php/AbeilleLog.php'; // logGetPluginLevel()
 
-class Abeille extends eqLogic {
+class Abeille extends eqLogic
+{
     // // Fonction dupliquée dans AbeilleParser.
     // public static function volt2pourcent($voltage) {
     //     $max = 3.135;
@@ -58,17 +59,18 @@ class Abeille extends eqLogic {
      * @return advice comment by question mark icon
      * @return state  if the test was successful or not
      */
-    public static function health() {
+    public static function health()
+    {
         $result = '';
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            if (config::byKey('ab::zgEnabled'.$zgId, 'Abeille', 'N') == 'N')
+            if (config::byKey('ab::zgEnabled' . $zgId, 'Abeille', 'N') == 'N')
                 continue; // Disabled
-            if (config::byKey('ab::zgType'.$zgId, 'Abeille', '') == 'WIFI')
+            if (config::byKey('ab::zgType' . $zgId, 'Abeille', '') == 'WIFI')
                 continue; // WIFI does not use a physical port
 
             if ($result != '')
                 $result .= ", ";
-            $result .= config::byKey('ab::zgPort'.$zgId, 'Abeille', '');
+            $result .= config::byKey('ab::zgPort' . $zgId, 'Abeille', '');
         }
 
         $return[] = array(
@@ -94,14 +96,15 @@ class Abeille extends eqLogic {
      *
      * @return Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function executePollCmds($period) {
+    public static function executePollCmds($period)
+    {
         $cmds = cmd::searchConfiguration('Polling', 'Abeille');
         foreach ($cmds as $cmd) {
             if ($cmd->getConfiguration('Polling') != $period)
                 continue;
             $eqLogic = $cmd->getEqLogic();
             $eqHName = $eqLogic->getHumanName();
-            log::add('Abeille', 'debug', "executePollCmds(".$period."): ".$eqHName.", cmd='".$cmd->getName()."' (".$cmd->getLogicalId().")");
+            log::add('Abeille', 'debug', "executePollCmds(" . $period . "): " . $eqHName . ", cmd='" . $cmd->getName() . "' (" . $cmd->getLogicalId() . ")");
             $cmd->execute();
         }
     }
@@ -114,19 +117,20 @@ class Abeille extends eqLogic {
      *
      * @return  Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function refreshCmd() {
+    public static function refreshCmd()
+    {
         global $abQueues;
 
         log::add('Abeille', 'debug', 'refreshCmd: start');
-        $i=15;
+        $i = 15;
         foreach (AbeilleCmd::searchConfiguration('RefreshData', 'Abeille') as $key => $cmd) {
-            if ($cmd->getConfiguration('RefreshData',0)) {
-                log::add('Abeille', 'debug', 'refreshCmd: '.$cmd->getHumanName().' ('.$cmd->getEqlogic()->getLogicalId().')' );
+            if ($cmd->getConfiguration('RefreshData', 0)) {
+                log::add('Abeille', 'debug', 'refreshCmd: ' . $cmd->getHumanName() . ' (' . $cmd->getEqlogic()->getLogicalId() . ')');
                 // $cmd->execute(); le process ne sont pas tous demarrer donc on met une tempo.
                 // $topic = $cmd->getEqlogic()->getLogicalId().'/'.$cmd->getLogicalId();
-                $topic = $cmd->getEqlogic()->getLogicalId().'/'.$cmd->getConfiguration('topic');
+                $topic = $cmd->getEqlogic()->getLogicalId() . '/' . $cmd->getConfiguration('topic');
                 $request = $cmd->getConfiguration('request');
-                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$topic."&time=".(time()+$i), $request);
+                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd" . $topic . "&time=" . (time() + $i), $request);
                 $i++;
             }
         }
@@ -175,7 +179,8 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cronDaily() {
+    public static function cronDaily()
+    {
         log::add('Abeille', 'debug', 'cronDaily() starting');
 
         $preventLQIRequest = config::byKey('ab::preventLQIAutoUpdate', 'Abeille', 'no');
@@ -184,9 +189,9 @@ class Abeille extends eqLogic {
         } else {
             // Refresh LQI once a day to get IEEE in prevision of futur changes, to get network topo as fresh as possible in json
             log::add('Abeille', 'debug', 'cronD: Starting LQI request (AbeilleLQI.php)');
-            $ROOT = __DIR__."/../php";
-            $cmd = "cd ".$ROOT."; nohup /usr/bin/php AbeilleLQI.php 1>/dev/null 2>/dev/null &";
-            log::add('Abeille', 'debug', 'cronD: cmd=\''.$cmd.'\'');
+            $ROOT = __DIR__ . "/../php";
+            $cmd = "cd " . $ROOT . "; nohup /usr/bin/php AbeilleLQI.php 1>/dev/null 2>/dev/null &";
+            log::add('Abeille', 'debug', 'cronD: cmd=\'' . $cmd . '\'');
             exec($cmd);
         }
 
@@ -201,42 +206,43 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cronHourly() {
+    public static function cronHourly()
+    {
         log::add('Abeille', 'debug', 'cronHourly() starting');
 
         // log::add('Abeille', 'debug', 'Check Zigate Presence');
 
         // $config = AbeilleTools::getConfig();
-// if (0) {
-//         //--------------------------------------------------------
-//         // Refresh Ampoule Ikea Bind et set Report
-//         log::add('Abeille', 'debug', 'Refresh Ampoule Ikea Bind et set Report');
+        // if (0) {
+        //         //--------------------------------------------------------
+        //         // Refresh Ampoule Ikea Bind et set Report
+        //         log::add('Abeille', 'debug', 'Refresh Ampoule Ikea Bind et set Report');
 
-//         $eqLogics = Abeille::byType('Abeille');
-//         $i = 0;
-//         foreach ($eqLogics as $eqLogic) {
-//             // Filtre sur Ikea
-//             if (strpos("_".$eqLogic->getConfiguration("ab::icon"), "IkeaTradfriBulb") > 0) {
-//                 list($dest, $addr) = explode("/", $eqLogic->getLogicalId());
-//                 $i = $i + 1;
+        //         $eqLogics = Abeille::byType('Abeille');
+        //         $i = 0;
+        //         foreach ($eqLogics as $eqLogic) {
+        //             // Filtre sur Ikea
+        //             if (strpos("_".$eqLogic->getConfiguration("ab::icon"), "IkeaTradfriBulb") > 0) {
+        //                 list($dest, $addr) = explode("/", $eqLogic->getLogicalId());
+        //                 $i = $i + 1;
 
-//                 // Recupere IEEE de la Ruche/ZiGate
-//                 $ZiGateIEEE = self::getIEEE($dest.'/0000');
+        //                 // Recupere IEEE de la Ruche/ZiGate
+        //                 $ZiGateIEEE = self::getIEEE($dest.'/0000');
 
-//                 // Recupere IEEE de l Abeille
-//                 $addrIEEE = self::getIEEE($dest.'/'.$addr);
+        //                 // Recupere IEEE de l Abeille
+        //                 $addrIEEE = self::getIEEE($dest.'/'.$addr);
 
-//                 log::add('Abeille', 'debug', 'Refresh bind and report for Ikea Bulb: '.$addr);
-//                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/bindShort&time=".(time() + (($i * 33) + 1)), "address=".$addr."&targetExtendedAddress=".$addrIEEE."&targetEndpoint=01&ClusterId=0006&reportToAddress=".$ZiGateIEEE);
-//                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/bindShort&time=".(time() + (($i * 33) + 2)), "address=".$addr."&targetExtendedAddress=".$addrIEEE."&targetEndpoint=01&ClusterId=0008&reportToAddress=".$ZiGateIEEE);
-//                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/setReport&time=".(time() + (($i * 33) + 3)), "address=".$addr."&ClusterId=0006&AttributeId=0000&AttributeType=10");
-//                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/setReport&time=".(time() + (($i * 33) + 4)), "address=".$addr."&ClusterId=0008&AttributeId=0000&AttributeType=20");
-//             }
-//         }
-//         if (($i * 33) > (3600)) {
-//             message::add("Abeille", "Danger il y a trop de message a envoyer dans le cron 1 heure.", "Contactez KiwiHC16 sur le Forum.");
-//         }
-//     }
+        //                 log::add('Abeille', 'debug', 'Refresh bind and report for Ikea Bulb: '.$addr);
+        //                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/bindShort&time=".(time() + (($i * 33) + 1)), "address=".$addr."&targetExtendedAddress=".$addrIEEE."&targetEndpoint=01&ClusterId=0006&reportToAddress=".$ZiGateIEEE);
+        //                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/bindShort&time=".(time() + (($i * 33) + 2)), "address=".$addr."&targetExtendedAddress=".$addrIEEE."&targetEndpoint=01&ClusterId=0008&reportToAddress=".$ZiGateIEEE);
+        //                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/setReport&time=".(time() + (($i * 33) + 3)), "address=".$addr."&ClusterId=0006&AttributeId=0000&AttributeType=10");
+        //                 Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/0000/setReport&time=".(time() + (($i * 33) + 4)), "address=".$addr."&ClusterId=0008&AttributeId=0000&AttributeType=20");
+        //             }
+        //         }
+        //         if (($i * 33) > (3600)) {
+        //             message::add("Abeille", "Danger il y a trop de message a envoyer dans le cron 1 heure.", "Contactez KiwiHC16 sur le Forum.");
+        //         }
+        //     }
         // Poll Cmd
         self::executePollCmds("cronHourly");
 
@@ -250,7 +256,8 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cron30() {
+    public static function cron30()
+    {
         // Poll Cmd
         self::executePollCmds("cron30");
     }
@@ -263,7 +270,8 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cron15() {
+    public static function cron15()
+    {
         global $abQueues;
 
         /* If main daemon is not running, cron must do nothing */
@@ -290,18 +298,18 @@ class Abeille extends eqLogic {
         $config = AbeilleTools::getConfig();
         $i = 0;
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            $zigate = Abeille::byLogicalId('Abeille'.$zgId.'/0000', 'Abeille');
+            $zigate = Abeille::byLogicalId('Abeille' . $zgId . '/0000', 'Abeille');
             if (!is_object($zigate))
                 continue; // Does not exist on Jeedom side.
             if (!$zigate->getIsEnable())
                 continue; // Zigate disabled
-            if ($config['ab::zgEnabled'.$zgId] != 'Y')
+            if ($config['ab::zgEnabled' . $zgId] != 'Y')
                 continue; // Zigate disabled.
 
             $eqLogics = Abeille::byType('Abeille');
             foreach ($eqLogics as $eqLogic) {
                 list($dest, $addr) = explode("/", $eqLogic->getLogicalId());
-                if ($dest != 'Abeille'.$zgId)
+                if ($dest != 'Abeille' . $zgId)
                     continue; // Not on current network
                 if (!$eqLogic->getIsEnable())
                     continue; // Equipment disabled
@@ -317,7 +325,7 @@ class Abeille extends eqLogic {
                 /* Checking if received some news in the last 15mins */
                 $cmd = $eqLogic->getCmd('info', 'Time-TimeStamp');
                 if (!is_object($cmd)) { // Cmd not found
-                    log::add('Abeille', 'warning', "cron15(): Commande 'Time-TimeStamp' manquante pour ".$eqName);
+                    log::add('Abeille', 'warning', "cron15(): Commande 'Time-TimeStamp' manquante pour " . $eqName);
                     continue; // No sense to interrogate EQ if Time-TimeStamp does not exists
                 }
                 $lastComm = $cmd->execCmd();
@@ -334,7 +342,7 @@ class Abeille extends eqLogic {
                 /* No news in the last 15mins. Need to interrogate this eq */
                 $mainEP = $eqLogic->getConfiguration("mainEP");
                 if (strlen($mainEP) <= 1) {
-                    log::add('Abeille', 'warning', "cron15(): 'End Point' principal manquant pour ".$eqName);
+                    log::add('Abeille', 'warning', "cron15(): 'End Point' principal manquant pour " . $eqName);
                     continue;
                 }
 
@@ -351,10 +359,10 @@ class Abeille extends eqLogic {
                     $poll += 100;
 
                 if ($poll > 0) {
-                    log::add('Abeille', 'debug', "cron15(): Interrogating '".$eqName."' (addr ".$addr.", poll-reason=".$poll.")");
+                    log::add('Abeille', 'debug', "cron15(): Interrogating '" . $eqName . "' (addr " . $addr . ", poll-reason=" . $poll . ")");
                     // Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/".$addr."/Annonce&time=".(time()+($i*23)), $mainEP);
                     // Reading ZCLVersion attribute which should always be supported
-                    Abeille::publishMosquitto($abQueues['xToCmd']['id'], PRIO_NORM, "TempoCmd".$dest."/".$addr."/readAttribute&time=".(time()+($i*23)), "ep=".$mainEP."&clustId=0000&attrId=0000");
+                    Abeille::publishMosquitto($abQueues['xToCmd']['id'], PRIO_NORM, "TempoCmd" . $dest . "/" . $addr . "/readAttribute&time=" . (time() + ($i * 23)), "ep=" . $mainEP . "&clustId=0000&attrId=0000");
                     $i++;
                 }
             }
@@ -377,7 +385,8 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cron10() {
+    public static function cron10()
+    {
         /* If main daemon is not running, cron must do nothing */
         if (AbeilleTools::isAbeilleCronRunning() == false) {
             log::add('Abeille', 'debug', 'cron10: Main daemon stopped => cron10 canceled');
@@ -395,7 +404,8 @@ class Abeille extends eqLogic {
      *
      * @return          Does not return anything as all action are triggered by sending messages in queues
      */
-    public static function cron5() {
+    public static function cron5()
+    {
         /* If main daemon is not running, cron must do nothing */
         if (AbeilleTools::isAbeilleCronRunning() == false) {
             log::add('Abeille', 'debug', 'cron5: Main daemon stopped => cron5 canceled');
@@ -420,7 +430,8 @@ class Abeille extends eqLogic {
      * @param none
      * @return nothing
      */
-    public static function cron() {
+    public static function cron()
+    {
         /* If main daemon is not running, cron must do nothing */
         if (AbeilleTools::isAbeilleCronRunning() == false) {
             log::add('Abeille', 'debug', 'cron(): Main daemon stopped => cron1 canceled');
@@ -439,9 +450,9 @@ class Abeille extends eqLogic {
         foreach ($dStatus['running']['daemons'] as $daemonName => $daemon) {
             if ($dTxt != "")
                 $dTxt .= ", ";
-            $dTxt .= $daemon['pid'].'/'.$daemonName;
+            $dTxt .= $daemon['pid'] . '/' . $daemonName;
         }
-        log::add('Abeille', 'debug', 'cron(): Daemons: '.$dTxt);
+        log::add('Abeille', 'debug', 'cron(): Daemons: ' . $dTxt);
 
         // Checking queues status to log any potential issue.
         // Moved from deamon_info()
@@ -450,32 +461,32 @@ class Abeille extends eqLogic {
             $queueId = $queueDesc['id'];
             $queue = msg_get_queue($queueId);
             if ($queue === false) {
-                log::add('Abeille', 'info', "cron(): ERREUR: Pb d'accès à la queue '".$queueName."' (id ".$queueId.")");
+                log::add('Abeille', 'info', "cron(): ERREUR: Pb d'accès à la queue '" . $queueName . "' (id " . $queueId . ")");
                 continue;
             }
             if (msg_stat_queue($queue)["msg_qnum"] > 100)
-                log::add('Abeille', 'info', "cron(): ERREUR: La queue '".$queueName."' (id ".$queueId.") contient plus de 100 messages.");
+                log::add('Abeille', 'info', "cron(): ERREUR: La queue '" . $queueName . "' (id " . $queueId . ") contient plus de 100 messages.");
         }
 
         // https://github.com/jeelabs/esp-link
         // The ESP-Link connections on port 23 and 2323 have a 5 minute inactivity timeout.
         // so I need to create a minimum of traffic, so pull zigate every minutes
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            if ($config['ab::zgEnabled'.$zgId] != 'Y')
+            if ($config['ab::zgEnabled' . $zgId] != 'Y')
                 continue; // Zigate disabled
-            if ($config['ab::zgPort'.$zgId] == "none")
+            if ($config['ab::zgPort' . $zgId] == "none")
                 continue; // Serial port undefined
             // TODO Tcharp38: Currently leads to PI zigate timeout. No sense since still alive.
             // if ($config['ab::zgType'.$zgId] != "WIFI")
             //     continue; // Not a WIFI zigate. No polling required
 
             // TODO: Better to read time to correct it if required, instead of version that rarely changes
-            Abeille::msgToCmd(PRIO_NORM, "CmdAbeille".$zgId."/0000/getZgVersion");
+            Abeille::msgToCmd(PRIO_NORM, "CmdAbeille" . $zgId . "/0000/getZgVersion");
 
             // Checking that Zigate is still alive
-            $eqLogic = eqLogic::byLogicalId('Abeille'.$zgId.'/0000', 'Abeille');
+            $eqLogic = eqLogic::byLogicalId('Abeille' . $zgId . '/0000', 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'error', "La ruche ".$zgId." a été détruite. Veuillez redémarrer Abeille.");
+                log::add('Abeille', 'error', "La ruche " . $zgId . " a été détruite. Veuillez redémarrer Abeille.");
                 continue;
             }
             $lastComm = $eqLogic->getStatus('lastCommunication', '');
@@ -486,26 +497,26 @@ class Abeille extends eqLogic {
                 $lastComm = strtotime($lastComm);
             // log::add('Abeille', 'info', "lastComm2=".$lastComm);
             if ((time() - $lastComm) > (2 * 60)) {
-                log::add('Abeille', 'info', "Pas de réponse de la Zigate ".$zgId." depuis plus de 2min");
-                $zgType = $config['ab::zgType'.$zgId];
-                $zgPort = $config['ab::zgPort'.$zgId];
+                log::add('Abeille', 'info', "Pas de réponse de la Zigate " . $zgId . " depuis plus de 2min");
+                $zgType = $config['ab::zgType' . $zgId];
+                $zgPort = $config['ab::zgPort' . $zgId];
                 if (($zgType == "USB") || ($zgType == "USBv2")) {
                     if ($config['ab::preventUsbPowerCycle'] == 'Y')
-                        log::add('Abeille', 'Debug', 'Power cycle required for Zigate '.$zgId.' but disabled');
+                        log::add('Abeille', 'Debug', 'Power cycle required for Zigate ' . $zgId . ' but disabled');
                     else {
-                        $dir = __DIR__."/../scripts";
-                        $cmd = "cd ".$dir."; ".system::getCmdSudo()." ./powerCycleUsb.sh ".$zgPort." 1>/tmp/jeedom/Abeille/powerCycleUsb.log 2>&1";
-                        log::add('Abeille', 'debug', 'Performing power cycle on port \''.$zgPort.'\'');
+                        $dir = __DIR__ . "/../scripts";
+                        $cmd = "cd " . $dir . "; " . system::getCmdSudo() . " ./powerCycleUsb.sh " . $zgPort . " 1>/tmp/jeedom/Abeille/powerCycleUsb.log 2>&1";
+                        log::add('Abeille', 'debug', 'Performing power cycle on port \'' . $zgPort . '\'');
                         exec($cmd, $output, $exitCode);
                         if ($exitCode != 0)
-                            message::add("Abeille", "La Zigate ".$zgId." semble plantée mais impossible de lui faire un cycle OFF/ON.");
+                            message::add("Abeille", "La Zigate " . $zgId . " semble plantée mais impossible de lui faire un cycle OFF/ON.");
                     }
                 } else if (($zgType == "PI") || ($zgType == "PIv2")) {
-                    log::add('Abeille', 'Debug', 'Performing HW reset on Zigate '.$zgId);
+                    log::add('Abeille', 'Debug', 'Performing HW reset on Zigate ' . $zgId);
                     exec("python /var/www/html/plugins/Abeille/core/scripts/resetPiZigate.py");
                 } else if (($zgType == "WIFI") || ($zgType == "WIFIv2")) {
-                    log::add('Abeille', 'Debug', 'Restarting socat for Zigate '.$zgId);
-                    AbeilleTools::restartDaemons($config, "Socat".$zgId." socat".$zgId);
+                    log::add('Abeille', 'Debug', 'Restarting socat for Zigate ' . $zgId);
+                    AbeilleTools::restartDaemons($config, "Socat" . $zgId . " socat" . $zgId);
                 }
             }
         }
@@ -524,10 +535,10 @@ class Abeille extends eqLogic {
             if (strlen($address) != 4)
                 continue; // Bad address, needed for virtual device
 
-            log::add('Abeille', 'debug', 'cron(): GetEtat/GetLevel, addr='.$address);
+            log::add('Abeille', 'debug', 'cron(): GetEtat/GetLevel, addr=' . $address);
             $mainEP = $eqLogic->getConfiguration('mainEP');
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/".$address."/readAttribute&time=".(time()+($i*3)), "ep=".$mainEP."&clustId=0006&attrId=0000");
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$dest."/".$address."/readAttribute&time=".(time()+($i*3)), "ep=".$mainEP."&clustId=0008&attrId=0000");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd" . $dest . "/" . $address . "/readAttribute&time=" . (time() + ($i * 3)), "ep=" . $mainEP . "&clustId=0006&attrId=0000");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd" . $dest . "/" . $address . "/readAttribute&time=" . (time() + ($i * 3)), "ep=" . $mainEP . "&clustId=0008&attrId=0000");
             $i++;
         }
         if (($i * 3) > 60) {
@@ -570,7 +581,7 @@ class Abeille extends eqLogic {
             }
 
             if ($newTimeoutS != $timeoutS) {
-                log::add('Abeille', 'debug', 'cron(): '.$eqLogic->getName().': timeout status changed to '.$newTimeoutS);
+                log::add('Abeille', 'debug', 'cron(): ' . $eqLogic->getName() . ': timeout status changed to ' . $newTimeoutS);
                 $newStatus = array(
                     'timeout' => $newTimeoutS,
                     // 'state' => $newState, // Tcharp38: Only used by Abeille. Really required ?
@@ -583,12 +594,12 @@ class Abeille extends eqLogic {
         // Je regarde si j ai deux zigate en inclusion et si oui je genere une alarme.
         $count = array();
         for ($i = 1; $i <= $GLOBALS['maxNbOfZigate']; $i++) {
-            if (self::checkInclusionStatus("Abeille".$i) == 1) {
-                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$i."/0000/permitJoin", "Status");
+            if (self::checkInclusionStatus("Abeille" . $i) == 1) {
+                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $i . "/0000/permitJoin", "Status");
                 $count[] = $i;
             }
         }
-        if (count($count) > 1) message::add("Abeille", "Danger vous avez plusieurs Zigate en mode inclusion: ".json_encode($count).". L equipement peut se joindre a l un ou l autre resau zigbee.", "Vérifier sur quel reseau se joint l equipement.");
+        if (count($count) > 1) message::add("Abeille", "Danger vous avez plusieurs Zigate en mode inclusion: " . json_encode($count) . ". L equipement peut se joindre a l un ou l autre resau zigbee.", "Vérifier sur quel reseau se joint l equipement.");
 
         // log::add( 'Abeille', 'debug', 'cron(): Fin ------------------------------------------------------------------------------------------------------------------------' );
     } // End cron()
@@ -598,7 +609,8 @@ class Abeille extends eqLogic {
      * @param none
      * @return array with state, launchable, launchable_message
      */
-    public static function deamon_info() {
+    public static function deamon_info()
+    {
         // $smId = @shmop_open(12, "a", 0, 0);
         // if ($smId !== false) {
         //     $smContent = shmop_read($smId, 0, shmop_size($smId));
@@ -635,7 +647,7 @@ class Abeille extends eqLogic {
             log::add('Abeille', 'warning', 'deamon_info(): Main daemon is not runnning.');
         }
 
-        log::add('Abeille', 'debug', 'deamon_info(): '.json_encode($status));
+        log::add('Abeille', 'debug', 'deamon_info(): ' . json_encode($status));
         return $status;
     }
 
@@ -643,7 +655,8 @@ class Abeille extends eqLogic {
         - run some cleanup
         - update the config database if changes needed
         Note: incorrect naming 'deamon' instead of 'daemon' due to Jeedom mistake. */
-    public static function deamon_start_cleanup() {
+    public static function deamon_start_cleanup()
+    {
         // log::add('Abeille', 'debug', 'deamon_start_cleanup(): Démarrage');
 
         // Remove Abeille's user messages
@@ -651,10 +664,10 @@ class Abeille extends eqLogic {
 
         // Remove any remaining temporary files
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            $lockFile = jeedom::getTmpFolder('Abeille').'/AbeilleLQI-Abeille'.$zgId.'.json.lock';
+            $lockFile = jeedom::getTmpFolder('Abeille') . '/AbeilleLQI-Abeille' . $zgId . '.json.lock';
             if (file_exists($lockFile)) {
                 unlink($lockFile);
-                log::add('Abeille', 'debug', 'deamon_start_cleanup(): Removed '.$lockFile);
+                log::add('Abeille', 'debug', 'deamon_start_cleanup(): Removed ' . $lockFile);
             }
         }
 
@@ -663,17 +676,17 @@ class Abeille extends eqLogic {
         //     "         = 0: IEEE check to be done
         //     "         = 1: Zigate on the right port
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            config::save("ab::zgIeeeAddrOk".$zgId, 0, 'Abeille');
+            config::save("ab::zgIeeeAddrOk" . $zgId, 0, 'Abeille');
         }
 
         /* Check & update configuration DB if required. */
         $dbVersion = config::byKey('ab::dbVersion', 'Abeille', '');
         $dbVersionLast = lastDbVersion;
         if (($dbVersion == '') || (intval($dbVersion) < $dbVersionLast)) {
-            log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v'.$dbVersion.' < v'.$dbVersionLast.' => Update required.');
+            log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v' . $dbVersion . ' < v' . $dbVersionLast . ' => Update required.');
             updateConfigDB();
         } else
-            log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v'.$dbVersion.' is up-to-date.');
+            log::add('Abeille', 'debug', 'deamon_start_cleanup(): DB config v' . $dbVersion . ' is up-to-date.');
 
         // Removing empty dir in "devices_local"
         AbeilleTools::cleanDevices();
@@ -685,11 +698,12 @@ class Abeille extends eqLogic {
     /* Jeedom required function.
        Starts all daemons.
        Note: incorrect naming 'deamon' instead of 'daemon' due to Jeedom mistake. */
-    public static function deamon_start($_debug = false) {
+    public static function deamon_start($_debug = false)
+    {
         $smId = @shmop_open(12, "a", 0, 0);
         if ($smId !== false) {
             $smContent = shmop_read($smId, 0, shmop_size($smId));
-            log::add('Abeille', 'debug', 'deamon_start(): starting. smContent='.$smContent);
+            log::add('Abeille', 'debug', 'deamon_start(): starting. smContent=' . $smContent);
             shmop_close($smId);
             $smContent = json_decode($smContent, true);
             if (isset($smContent['daemonsPaused']) && ($smContent['daemonsPaused'] == true)) {
@@ -724,28 +738,28 @@ class Abeille extends eqLogic {
         /* Checking config */
         // TODO Tcharp38: Should be done during deamon_info() and report proper 'launchable'
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            if ($config['ab::zgEnabled'.$zgId] != 'Y')
+            if ($config['ab::zgEnabled' . $zgId] != 'Y')
                 continue; // Disabled
 
             /* This zigate is enabled. Checking other parameters */
             $error = "";
-            $sp = $config['ab::zgPort'.$zgId];
+            $sp = $config['ab::zgPort' . $zgId];
             if (($sp == 'none') || ($sp == "")) {
-                $error = "Port série de la zigate ".$zgId." INVALIDE";
+                $error = "Port série de la zigate " . $zgId . " INVALIDE";
             }
             if ($error == "") {
-                if ($config['ab::zgType'.$zgId] == "WIFI") {
-                    $wifiAddr = $config['ab::zgIpAddr'.$zgId];
+                if ($config['ab::zgType' . $zgId] == "WIFI") {
+                    $wifiAddr = $config['ab::zgIpAddr' . $zgId];
                     if (($wifiAddr == 'none') || ($wifiAddr == "")) {
-                        $error = "Adresse Wifi de la zigate ".$zgId." INVALIDE";
+                        $error = "Adresse Wifi de la zigate " . $zgId . " INVALIDE";
                     }
                 }
             }
             if ($error != "") {
-                $config['ab::zgEnabled'.$zgId] = 'N';
-                config::save('ab::zgEnabled'.$zgId, 'N', 'Abeille');
-                log::add('Abeille', 'error', $error." => Zigate désactivée.");
-            } else if (($config['ab::zgType'.$zgId] == "PI") || ($config['ab::zgType'.$zgId] == "PIv2")) {
+                $config['ab::zgEnabled' . $zgId] = 'N';
+                config::save('ab::zgEnabled' . $zgId, 'N', 'Abeille');
+                log::add('Abeille', 'error', $error . " => Zigate désactivée.");
+            } else if (($config['ab::zgType' . $zgId] == "PI") || ($config['ab::zgType' . $zgId] == "PIv2")) {
                 /* Configuring GPIO for PiZigate if one active found.
                     PiZigate reminder (using 'WiringPi'):
                     - port 0 = RESET
@@ -767,11 +781,11 @@ class Abeille extends eqLogic {
         // TODO Tcharp38: Note: This should not longer be required as the parser itself do the request on startup
         $expected = 0; // 1 bit per expected serial read daemon
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            if (($config['ab::zgPort'.$zgId] == 'none') or ($config['ab::zgEnabled'.$zgId] != 'Y'))
+            if (($config['ab::zgPort' . $zgId] == 'none') or ($config['ab::zgEnabled' . $zgId] != 'Y'))
                 continue; // Undefined or disabled
-            $expected |= constant("daemonSerialRead".$zgId);
-            if ($config['ab::zgType'.$zgId] == 'WIFI')
-                $expected |= constant("daemonSocat".$zgId);
+            $expected |= constant("daemonSerialRead" . $zgId);
+            if ($config['ab::zgType' . $zgId] == 'WIFI')
+                $expected |= constant("daemonSocat" . $zgId);
         }
         $timeout = 10;
         for ($t = 0; $t < $timeout; $t++) {
@@ -794,7 +808,7 @@ class Abeille extends eqLogic {
         if (logGetPluginLevel() == 4) {
             $jLines = log::getConfig('maxLineLog');
             if ($jLines < 5000)
-                message::add("Abeille", "Vous êtes en mode debug mais le nombre de lignes est inférieur à 5000 (".$jLines."). Il est recommandé d'augmenter ce nombre pour tout besoin de support.");
+                message::add("Abeille", "Vous êtes en mode debug mais le nombre de lignes est inférieur à 5000 (" . $jLines . "). Il est recommandé d'augmenter ce nombre pour tout besoin de support.");
         }
 
         log::add('Abeille', 'debug', 'deamon_start(): Terminé');
@@ -803,7 +817,8 @@ class Abeille extends eqLogic {
 
     /* Jeedom required function.
        Stopping all daemons and removing queues */
-    public static function deamon_stop() {
+    public static function deamon_stop()
+    {
         log::add('Abeille', 'debug', 'deamon_stop(): Starting');
 
         /* Stopping cron */
@@ -836,7 +851,8 @@ class Abeille extends eqLogic {
     }
 
     /* Temporary stop daemons and prevent auto-restart from Jeedom */
-    public static function pauseDaemons($start) {
+    public static function pauseDaemons($start)
+    {
         $smId = shmop_open(12, "c", 0644, 50);
         $smContent = [];
         if ($start)
@@ -846,7 +862,7 @@ class Abeille extends eqLogic {
         shmop_write($smId, json_encode($smContent), 0);
         shmop_close($smId);
 
-        log::add('Abeille', 'debug', 'pauseDaemons('.$start.')');
+        log::add('Abeille', 'debug', 'pauseDaemons(' . $start . ')');
         if ($start) {
             $daemons = AbeilleTools::getRunningDaemons2();
             if ($daemons['runBits'] == 0)
@@ -864,21 +880,23 @@ class Abeille extends eqLogic {
     }
 
     /* Called from Jeedom to install dependencies */
-    public static function dependancy_install() {
+    public static function dependancy_install()
+    {
         log::add('Abeille', 'debug', 'dependancy_install()');
 
         message::add("Abeille", "Installation des dépendances en cours.", "N'oubliez pas de lire la documentation: https://kiwihc16.github.io/AbeilleDoc");
-        log::remove(__CLASS__.'_update');
+        log::remove(__CLASS__ . '_update');
         $result = [
-            'script' => __DIR__.'/../scripts/installDependencies.sh '.jeedom::getTmpFolder('Abeille').'/dependencies_progress',
-            'log' => log::getPathToLog(__CLASS__.'_update')
+            'script' => __DIR__ . '/../scripts/installDependencies.sh ' . jeedom::getTmpFolder('Abeille') . '/dependencies_progress',
+            'log' => log::getPathToLog(__CLASS__ . '_update')
         ];
 
         return $result;
     }
 
     /* Called from Jeedom to display dependencies status */
-    public static function dependancy_info() {
+    public static function dependancy_info()
+    {
         log::add('Abeille', 'debug', 'dependancy_info()');
 
         // // Called by js dans plugin.class.js(getDependancyInfo) -> plugin.ajax.php(dependancy_info())
@@ -918,12 +936,13 @@ class Abeille extends eqLogic {
                 $return['state'] = 'ok';
             }
         }
-        log::add('Abeille', 'debug', 'dependancy_info: '.json_encode($return));
+        log::add('Abeille', 'debug', 'dependancy_info: ' . json_encode($return));
         return $return;
     }
 
     /* This is Abeille's main daemon, directly controlled by Jeedom itself. */
-    public static function deamon() {
+    public static function deamon()
+    {
         global $abQueues;
 
         log::add('Abeille', 'debug', 'deamon(): Main daemon starting');
@@ -935,29 +954,29 @@ class Abeille extends eqLogic {
         // Tcharp38: Moved from deamon_start()
         $config = AbeilleTools::getConfig();
         for ($zgId = 1; $zgId <= $GLOBALS['maxNbOfZigate']; $zgId++) {
-            if (($config['ab::zgPort'.$zgId] == 'none') or ($config['ab::zgEnabled'.$zgId] != 'Y'))
+            if (($config['ab::zgPort' . $zgId] == 'none') or ($config['ab::zgEnabled' . $zgId] != 'Y'))
                 continue; // Undefined or disabled
 
             // Create/update beehive equipment on Jeedom side
             // Note: This will reset 'FW-Version' to '---------' to mark FW version invalid.
             // Abeille::publishMosquitto($abQueues["xToAbeille"]["id"], priorityInterrogation, "CmdRuche/0000/CreateRuche", "Abeille".$zgId);
-            self::createRuche("Abeille".$zgId);
+            self::createRuche("Abeille" . $zgId);
 
             // Configuring zigate: TODO: This should be done on Abeille startup or on new beehive creation.
-            if (isset($config['ab::zgChan'.$zgId])) {
-                $chan = $config['ab::zgChan'.$zgId];
+            if (isset($config['ab::zgChan' . $zgId])) {
+                $chan = $config['ab::zgChan' . $zgId];
                 if ($chan == 0)
                     $mask = 0x7fff800; // All channels = auto
                 else
                     $mask = 1 << $chan;
                 $mask = sprintf("%08X", $mask);
-                log::add('Abeille', 'debug', "deamon(): Settings chan ".$chan." (mask=".$mask.") for zigate ".$zgId);
-                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/setZgChannelMask", "mask=".$mask);
+                log::add('Abeille', 'debug', "deamon(): Settings chan " . $chan . " (mask=" . $mask . ") for zigate " . $zgId);
+                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/setZgChannelMask", "mask=" . $mask);
             }
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/resetZg", "");
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/startZgNetwork", "");
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/setZgTimeServer", "");
-            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/getZgVersion", "");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/resetZg", "");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/startZgNetwork", "");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/setZgTimeServer", "");
+            Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/getZgVersion", "");
 
             // Set Zigate in 'hybrid' mode, (possible only since 3.1D).
             // Tcharp38: Need to get current FW version first so this part if moved to 'msgFromParser' on 'zigateVersion' recept.
@@ -1034,13 +1053,13 @@ class Abeille extends eqLogic {
                 } else { // Error
                     if ($errCode == 7) {
                         msg_receive($queueXToAbeille, 0, $msgType, $msgMax, $msgJson, false, MSG_IPC_NOWAIT | MSG_NOERROR);
-                        log::add('Abeille', 'error', "Message (xToAbeille) trop grand ignoré: ".$msgJson);
+                        log::add('Abeille', 'error', "Message (xToAbeille) trop grand ignoré: " . $msgJson);
                     } else if ($errCode != 42)
-                        log::add('Abeille', 'error', 'deamon(): msg_receive(xToAbeille) erreur '.$errCode.', msg='.$msgJson);
+                        log::add('Abeille', 'error', 'deamon(): msg_receive(xToAbeille) erreur ' . $errCode . ', msg=' . $msgJson);
                 }
             }
         } catch (Exception $e) {
-            log::add('Abeille', 'error', 'deamon(): Exception '.$e->getMessage());
+            log::add('Abeille', 'error', 'deamon(): Exception ' . $e->getMessage());
         }
 
         log::add('Abeille', 'debug', 'deamon(): Main daemon stopped');
@@ -1163,7 +1182,7 @@ class Abeille extends eqLogic {
     public static function checkInclusionStatus($dest)
     {
         // Return: Inclusion status or -1 if error
-        $ruche = Abeille::byLogicalId($dest.'/0000', 'Abeille');
+        $ruche = Abeille::byLogicalId($dest . '/0000', 'Abeille');
 
         if ($ruche) {
             // echo "Join status collection\n";
@@ -1274,9 +1293,10 @@ class Abeille extends eqLogic {
     // TODO: To be moved in AbeilleTools. Could be used by parser too
     // Attempt to find model corresponding to given zigbee signature.
     // Returns: associative array('jsonId', 'jsonLocation') or false
-    public static function findModel($zbModelId, $zbManufId) {
+    public static function findModel($zbModelId, $zbManufId)
+    {
 
-        $identifier1 = $zbModelId.'_'.$zbManufId;
+        $identifier1 = $zbModelId . '_' . $zbManufId;
         $identifier2 = $zbModelId;
 
         // Search by <zbModelId>_<zbManufId>, starting from local models list
@@ -1321,7 +1341,8 @@ class Abeille extends eqLogic {
         return $model;
     }
 
-    public static function message($topic, $payload) {
+    public static function message($topic, $payload)
+    {
         // KiwiHC16: Please leave this line log::add commented otherwise too many messages in log Abeille
         // and keep the 3 lines below which print all messages except Time-Time, Time-TimeStamp and Link-Quality that we get for every message.
         // Divide by 3 the log quantity and ease the log reading
@@ -1329,7 +1350,7 @@ class Abeille extends eqLogic {
 
         $topicArray = explode("/", $topic);
         if (sizeof($topicArray) != 3) {
-            log::add('Abeille', 'debug', "ERROR: Invalid message: topic=".$topic);
+            log::add('Abeille', 'debug', "ERROR: Invalid message: topic=" . $topic);
             return;
         }
 
@@ -1372,10 +1393,10 @@ class Abeille extends eqLogic {
 
         // log all messages except the one related to Time, which overload the log
         if (!in_array($cmdId, array("Time-Time", "Time-TimeStamp", "Link-Quality"))) {
-            log::add('Abeille', 'debug', "message(topic='".$topic."', payload='".$payload."')");
+            log::add('Abeille', 'debug', "message(topic='" . $topic . "', payload='" . $payload . "')");
         }
 
-        $nodeid = $net.'/'.$addr;
+        $nodeid = $net . '/' . $addr;
         $value = $payload;
         $type = 'topic';         // type = topic car pas json
 
@@ -1452,11 +1473,11 @@ class Abeille extends eqLogic {
                 $action = 'update';
             else
                 $action = 'reset';
-            log::add('Abeille', 'debug', 'message(): '.$cmdId.', '.$net.'/'.$addr);
+            log::add('Abeille', 'debug', 'message(): ' . $cmdId . ', ' . $net . '/' . $addr);
 
-            $eqLogic = Abeille::byLogicalId($net.'/'.$addr, 'Abeille');
+            $eqLogic = Abeille::byLogicalId($net . '/' . $addr, 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'error', '  '.$cmdId.': Equipement inconnu: '.$net.'/'.$addr);
+                log::add('Abeille', 'error', '  ' . $cmdId . ': Equipement inconnu: ' . $net . '/' . $addr);
                 return;
             }
 
@@ -1468,7 +1489,11 @@ class Abeille extends eqLogic {
             // Checking if model is defaultUnknown and there is now a real model for it (see #2211).
             // Also rechecking if model is still the correct one (ex: TS011F => TS011F__TZ3000_2putqrmw)
             $eqSig = $eqLogic->getConfiguration('ab::signature', []);
-            if ($eqSig != [] && $eqSig['modelId'] != "") {
+
+            // Changement automatique du modèle interdit si l'utilisateur l'a choisi lui-même
+            $isManualModel = $eqLogic->getConfiguration('ab::isManualModel', false);
+
+            if ($eqSig != [] && $eqSig['modelId'] != "" && !$isManualModel) {
                 // Any user or official model ?
                 $modelInfos = self::findModel($eqSig['modelId'], $eqSig['manufId']);
                 if ($modelInfos !== false) {
@@ -1478,7 +1503,7 @@ class Abeille extends eqLogic {
                 }
             }
             if ($jsonId != $jsonId1)
-                message::add("Abeille", $eqHName.": Nouveau modèle trouvé. Mise-à-jour en cours.", '');
+                message::add("Abeille", $eqHName . ": Nouveau modèle trouvé. Mise-à-jour en cours.", '');
 
             $dev = array(
                 'net' => $dest,
@@ -1487,6 +1512,9 @@ class Abeille extends eqLogic {
                 'jsonLocation' => $jsonLocation,
                 'ieee' => $eqLogic->getConfiguration('IEEE'),
             );
+
+
+
             Abeille::createDevice($action, $dev);
 
             return;
@@ -1622,7 +1650,7 @@ class Abeille extends eqLogic {
             // exemple: le Xiaomi Wall Switch 2 Bouton envoie un On et un Off dans le même message donc Abeille recoit un ON/OFF consecutif et
             // ne sais pas vraiment le gérer donc ici on rejete le Off et on met un retour d'etat dans la commande Jeedom
             if ($cmdLogic->getConfiguration('AbeilleRejectValue', -9999.99) == $value) {
-                log::add('Abeille', 'debug', 'Rejet de la valeur: '.$cmdLogic->getConfiguration('AbeilleRejectValue', -9999.99).' - '.$value);
+                log::add('Abeille', 'debug', 'Rejet de la valeur: ' . $cmdLogic->getConfiguration('AbeilleRejectValue', -9999.99) . ' - ' . $value);
 
                 return;
             }
@@ -1656,7 +1684,8 @@ class Abeille extends eqLogic {
 
     /* Trig another command defined by 'trigLogicId'.
        The 'newValue' is computed with 'trigOffset' if required then applied to 'trigLogicId' */
-    public static function trigCommand($eqLogic, $newValue, $trigLogicId, $trigOffset = null) {
+    public static function trigCommand($eqLogic, $newValue, $trigLogicId, $trigOffset = null)
+    {
         if ($trigOffset)
             $trigValue = jeedom::evaluateExpression(str_replace('#value#', $newValue, $trigOffset));
         else
@@ -1665,20 +1694,21 @@ class Abeille extends eqLogic {
         $trigCmd = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $trigLogicId);
         if ($trigCmd) {
             $trigName = $trigCmd->getName();
-            log::add('Abeille', 'debug', "  Triggering cmd '".$trigName."' (".$trigLogicId.") with val=".$trigValue);
+            log::add('Abeille', 'debug', "  Triggering cmd '" . $trigName . "' (" . $trigLogicId . ") with val=" . $trigValue);
             $eqLogic->checkAndUpdateCmd($trigCmd, $trigValue);
         }
 
         if (preg_match("/^0001-[0-9A-F]*-0021/", $trigLogicId)) {
             $trigValue = round($trigValue, 0);
-            log::add('Abeille', 'debug', "  Battery % reporting: ".$trigLogicId.", val=".$trigValue);
+            log::add('Abeille', 'debug', "  Battery % reporting: " . $trigLogicId . ", val=" . $trigValue);
             $eqLogic->setStatus('battery', $trigValue);
             $eqLogic->setStatus('batteryDatetime', date('Y-m-d H:i:s'));
         }
     }
 
     /* Called on info cmd update (attribute report or attribute read) to see if any action cmd must be executed */
-    public static function infoCmdUpdate($eqLogic, $cmdLogic, $value) {
+    public static function infoCmdUpdate($eqLogic, $cmdLogic, $value)
+    {
         global $abQueues;
 
         // Trig another command ('ab::trigOut' eqLogic config) ?
@@ -1696,16 +1726,17 @@ class Abeille extends eqLogic {
                 continue;
             $delay = $cmd->getConfiguration('PollingOnCmdChangeDelay', '');
             if ($delay != 0) {
-                log::add('Abeille', 'debug', "  Triggering '".$cmd->getName()."' with delay ".$delay);
-                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$eqLogic->getLogicalId()."/".$cmd->getConfiguration('topic')."&time=".(time() + $delay), $cmd->getConfiguration('request'));
+                log::add('Abeille', 'debug', "  Triggering '" . $cmd->getName() . "' with delay " . $delay);
+                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd" . $eqLogic->getLogicalId() . "/" . $cmd->getConfiguration('topic') . "&time=" . (time() + $delay), $cmd->getConfiguration('request'));
             } else {
-                log::add('Abeille', 'debug', "  Triggering '".$cmd->getName()."'");
-                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd".$eqLogic->getLogicalId()."/".$cmd->getConfiguration('topic')."&time=".time(), $cmd->getConfiguration('request'));
+                log::add('Abeille', 'debug', "  Triggering '" . $cmd->getName() . "'");
+                Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "TempoCmd" . $eqLogic->getLogicalId() . "/" . $cmd->getConfiguration('topic') . "&time=" . time(), $cmd->getConfiguration('request'));
             }
         }
     }
 
-    public static function checkZgIeee($net, $ieee) {
+    public static function checkZgIeee($net, $ieee)
+    {
         $zgId = substr($net, 7);
         $keyIeee = str_replace('Abeille', 'ab::zgIeeeAddr', $net); // AbeilleX => ab::zgIeeeAddrX
         $keyIeeeOk = str_replace('Abeille', 'ab::zgIeeeAddrOk', $net); // AbeilleX => ab::zgIeeeAddrOkX
@@ -1718,13 +1749,14 @@ class Abeille extends eqLogic {
                 config::save($keyIeeeOk, 1, 'Abeille');
             } else {
                 config::save($keyIeeeOk, -1, 'Abeille');
-                message::add("Abeille", "Attention: La zigate ".$zgId." semble nouvelle ou il y a eu échange de ports. Tous ses messages sont ignorés par mesure de sécurité. Assurez vous que les zigates restent sur le meme port, même après reboot.", 'Abeille/Demon');
+                message::add("Abeille", "Attention: La zigate " . $zgId . " semble nouvelle ou il y a eu échange de ports. Tous ses messages sont ignorés par mesure de sécurité. Assurez vous que les zigates restent sur le meme port, même après reboot.", 'Abeille/Demon');
             }
         }
     }
 
     // Check if received attribute is a battery information
-    public static function checkIfBatteryInfo($eqLogic, $attrName, $attrVal) {
+    public static function checkIfBatteryInfo($eqLogic, $attrName, $attrVal)
+    {
         // if ($attrName == "Battery-Volt") { // Obsolete
         //     $attrVal = round($attrVal, 0);
         //     $eqLogic->setStatus('battery', self::volt2pourcent($attrVal));
@@ -1732,12 +1764,12 @@ class Abeille extends eqLogic {
         // } else
         if (($attrName == "Battery-Percent") || ($attrName == "Batterie-Pourcent")) {  // Obsolete
             $attrVal = round($attrVal, 0);
-            log::add('Abeille', 'debug', "  Battery % reporting: ".$attrName.", val=".$attrVal);
+            log::add('Abeille', 'debug', "  Battery % reporting: " . $attrName . ", val=" . $attrVal);
             $eqLogic->setStatus('battery', $attrVal);
             $eqLogic->setStatus('batteryDatetime', date('Y-m-d H:i:s'));
-        }  else if (preg_match("/^0001-[0-9A-F]*-0021/", $attrName)) {
+        } else if (preg_match("/^0001-[0-9A-F]*-0021/", $attrName)) {
             $attrVal = round($attrVal, 0);
-            log::add('Abeille', 'debug', "  Battery % reporting: ".$attrName.", val=".$attrVal);
+            log::add('Abeille', 'debug', "  Battery % reporting: " . $attrName . ", val=" . $attrVal);
             $eqLogic->setStatus('battery', $attrVal);
             $eqLogic->setStatus('batteryDatetime', date('Y-m-d H:i:s'));
         }
@@ -1745,7 +1777,8 @@ class Abeille extends eqLogic {
 
     /* Deal with messages coming from parser.
        Note: this is the new way to handle messages from parser, replacing progressively 'message()' */
-    public static function msgFromParser($msg) {
+    public static function msgFromParser($msg)
+    {
         global $abQueues;
 
         $net = $msg['net'];
@@ -1759,7 +1792,7 @@ class Abeille extends eqLogic {
         /* Parser has found a new device. Basic Jeedom entry to be created. */
         if ($msg['type'] == "newDevice") {
             $ieee = $msg['ieee'];
-            log::add('Abeille', 'debug', "msgFromParser(): New device: ".$net.'/'.$addr.", ieee=".$ieee);
+            log::add('Abeille', 'debug', "msgFromParser(): New device: " . $net . '/' . $addr . ", ieee=" . $ieee);
 
             Abeille::newJeedomDevice($net, $addr, $ieee);
             return;
@@ -1767,9 +1800,9 @@ class Abeille extends eqLogic {
 
         /* Parser has found device infos to update. */
         if ($msg['type'] == "deviceUpdates") {
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.'/'.$addr.'/'.$ep.", Device updates, ".json_encode($msg, JSON_UNESCAPED_SLASHES));
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . '/' . $addr . '/' . $ep . ", Device updates, " . json_encode($msg, JSON_UNESCAPED_SLASHES));
 
-            $eqLogic = eqLogic::byLogicalId($net.'/'.$addr, 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . '/' . $addr, 'Abeille');
             $eqChanged = false;
             foreach ($msg['updates'] as $updKey => $updVal) {
                 if ($updKey == 'ieee') {
@@ -1779,8 +1812,8 @@ class Abeille extends eqLogic {
                             $ieee2 = $eqLogic->getConfiguration('IEEE', '');
                             if ($ieee2 != $updVal)
                                 continue;
-                            $eqLogic->setLogicalId($net.'/'.$addr);
-                            log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'addr' updated to ".$addr);
+                            $eqLogic->setLogicalId($net . '/' . $addr);
+                            log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'addr' updated to " . $addr);
                             $eqLogic->setIsEnable(1);
                             $eqChanged = true;
                             break;
@@ -1794,28 +1827,28 @@ class Abeille extends eqLogic {
                         $zigbee['mainsPowered'] = ($mc >> 2) & 0b1; // 1=mains-powered
                         $zigbee['rxOnWhenIdle'] = ($mc >> 3) & 0b1;
                         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                        log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[macCapa]' updated to ".$updVal);
+                        log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[macCapa]' updated to " . $updVal);
                         $eqChanged = true;
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'rxOnWhenIdle') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         $zigbee['rxOnWhenIdle'] = $updVal;
                         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                        log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[rxOnWhenIdle]' updated to ".$updVal);
+                        log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[rxOnWhenIdle]' updated to " . $updVal);
                         $eqChanged = true;
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'endPoints') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         $zigbee['endPoints'] = $updVal;
                         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                        log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[endPoints]' updated to ".json_encode($updVal));
+                        log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[endPoints]' updated to " . json_encode($updVal));
                         $eqChanged = true;
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'servClusters') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
@@ -1823,52 +1856,52 @@ class Abeille extends eqLogic {
                         if (strpos($updVal, '0004') !== false)
                             $zigbee['groups'][$ep] = '';
                         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                        log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[endPoints]['.$ep.']['servClusters']' updated to ".json_encode($updVal));
+                        log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[endPoints]['.$ep.']['servClusters']' updated to " . json_encode($updVal));
                         $eqChanged = true;
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'manufId') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         if (!isset($zigbee['endPoints'][$ep]['manufId'])) {
                             $zigbee['endPoints'][$ep]['manufId'] = $updVal;
                             $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                            log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[endPoints]['.$ep.']['manufId']' updated to ".json_encode($updVal));
+                            log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[endPoints]['.$ep.']['manufId']' updated to " . json_encode($updVal));
                             $eqChanged = true;
                         }
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'modelId') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         if (!isset($zigbee['endPoints'][$ep]['modelId'])) {
                             $zigbee['endPoints'][$ep]['modelId'] = $updVal;
                             $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                            log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[endPoints]['.$ep.']['modelId']' updated to ".json_encode($updVal));
+                            log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[endPoints]['.$ep.']['modelId']' updated to " . json_encode($updVal));
                             $eqChanged = true;
                         }
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'location') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         if (!isset($zigbee['endPoints'][$ep]['location'])) {
                             $zigbee['endPoints'][$ep]['location'] = $updVal;
                             $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                            log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[endPoints]['.$ep.']['location']' updated to ".json_encode($updVal));
+                            log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[endPoints]['.$ep.']['location']' updated to " . json_encode($updVal));
                             $eqChanged = true;
                         }
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 } else if ($updKey == 'manufCode') {
                     if (is_object($eqLogic)) {
                         $zigbee = $eqLogic->getConfiguration('ab::zigbee', []);
                         $zigbee['manufCode'] = $updVal;
                         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
-                        log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().": 'ab::zigbee[manufCode]' updated to ".$updVal);
+                        log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ": 'ab::zigbee[manufCode]' updated to " . $updVal);
                         $eqChanged = true;
                     } else
-                        log::add('Abeille', 'debug', '  ERROR: Unknown '.$net.'/'.$addr." device");
+                        log::add('Abeille', 'debug', '  ERROR: Unknown ' . $net . '/' . $addr . " device");
                 }
             }
             if ($eqChanged)
@@ -1894,10 +1927,10 @@ class Abeille extends eqLogic {
                     'time' => time()
                 ); */
 
-            $logicalId = $net.'/'.$addr;
+            $logicalId = $net . '/' . $addr;
             $jsonId = $msg['jsonId'];
             $jsonLocation = $msg['jsonLocation']; // 'Abeille' or 'local'
-            log::add('Abeille', 'debug', "msgFromParser(): Eq announce received for ".$net.'/'.$addr.", jsonId='".$jsonId."'".", jsonLoc='".$jsonLocation."'");
+            log::add('Abeille', 'debug', "msgFromParser(): Eq announce received for " . $net . '/' . $addr . ", jsonId='" . $jsonId . "'" . ", jsonLoc='" . $jsonLocation . "'");
 
             $ieee = $msg['ieee'];
 
@@ -1908,7 +1941,7 @@ class Abeille extends eqLogic {
                 $all = self::byType('Abeille');
                 foreach ($all as $key => $eqLogic) {
                     $eqLogicId = $eqLogic->getLogicalId(); // Ex: 'Abeille1/xxxx'
-                    list($net2, $addr2) = explode( "/", $eqLogicId);
+                    list($net2, $addr2) = explode("/", $eqLogicId);
                     if ($net2 != $net)
                         continue; // Not on expected network
                     if ((substr($addr2, 0, 2) == "rc") || ($addr2 == ""))
@@ -1916,7 +1949,7 @@ class Abeille extends eqLogic {
 
                     $ieee2 = $eqLogic->getConfiguration('IEEE', '');
                     if ($ieee2 == '') {
-                        log::add('Abeille', 'debug', "msgFromParser(): WARNING. No IEEE addr in '".$eqLogicId."' config.");
+                        log::add('Abeille', 'debug', "msgFromParser(): WARNING. No IEEE addr in '" . $eqLogicId . "' config.");
                         continue; // No registered IEEE
                     }
                     if ($ieee2 != $ieee)
@@ -1924,7 +1957,7 @@ class Abeille extends eqLogic {
 
                     $eqLogic->setLogicalId($logicalId); // Updating logical ID
                     $eqLogic->save();
-                    log::add('Abeille', 'debug', "msgFromParser(): Eq found with old addr ".$addr2.". Update done.");
+                    log::add('Abeille', 'debug', "msgFromParser(): Eq found with old addr " . $addr2 . ". Update done.");
                     break; // No need to go thru other equipments
                 }
             }
@@ -1993,20 +2026,20 @@ class Abeille extends eqLogic {
             // 'srcNet' => $oldNet,
             // 'srcAddr' => $oldAddr,
 
-            $oldLogicId = $msg['srcNet'].'/'.$msg['srcAddr'];
-            log::add('Abeille', 'debug', "msgFromParser(): Device migration from ".$oldLogicId." to ".$net."/".$addr);
+            $oldLogicId = $msg['srcNet'] . '/' . $msg['srcAddr'];
+            log::add('Abeille', 'debug', "msgFromParser(): Device migration from " . $oldLogicId . " to " . $net . "/" . $addr);
 
             $eqLogic = eqLogic::byLogicalId($oldLogicId, 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: ".$oldLogicId." is unknown");
+                log::add('Abeille', 'debug', "  ERROR: " . $oldLogicId . " is unknown");
                 return;
             }
 
             // Moving eq to new network
-            $eqLogic->setLogicalId($net.'/'.$addr);
+            $eqLogic->setLogicalId($net . '/' . $addr);
             $eqLogic->setIsEnable(1);
             $eqLogic->save();
-            message::add("Abeille", $eqLogic->getHumanName().": a migré vers le réseau ".$net, '');
+            message::add("Abeille", $eqLogic->getHumanName() . ": a migré vers le réseau " . $net, '');
 
             return;
         } // End 'eqMigrated'
@@ -2024,14 +2057,14 @@ class Abeille extends eqLogic {
             */
 
             $ieee = $msg['ieee'];
-            log::add('Abeille', 'debug', "msgFromParser(): Leave indication for ".$net."/".$ieee.", rejoin=".$msg['rejoin']);
+            log::add('Abeille', 'debug', "msgFromParser(): Leave indication for " . $net . "/" . $ieee . ", rejoin=" . $msg['rejoin']);
 
             /* Look for corresponding equipment (identified via its IEEE addr) */
             $all = self::byType('Abeille');
             $eqLogic = null;
             foreach ($all as $key => $eqLogic2) {
                 $eqLogicId2 = $eqLogic2->getLogicalId(); // Ex: 'Abeille1/xxxx'
-                list($net2, $addr2) = explode( "/", $eqLogicId2);
+                list($net2, $addr2) = explode("/", $eqLogicId2);
                 if ($net2 != $net)
                     continue; // Not on expected network
                 if ((substr($addr2, 0, 2) == "rc") || ($addr2 == ""))
@@ -2039,7 +2072,7 @@ class Abeille extends eqLogic {
 
                 $ieee2 = $eqLogic2->getConfiguration('IEEE', '');
                 if ($ieee2 == '') {
-                    log::add('Abeille', 'debug', "msgFromParser(): WARNING. No IEEE addr in '".$eqLogicId2."' config.");
+                    log::add('Abeille', 'debug', "msgFromParser(): WARNING. No IEEE addr in '" . $eqLogicId2 . "' config.");
                     $cmd = $eqLogic2->getCmd('info', 'IEEE-Addr');
                     if (is_object($cmd)) {
                         $ieee2 = $cmd->execCmd();
@@ -2063,14 +2096,14 @@ class Abeille extends eqLogic {
                 $eqLogic->setIsEnable(0);
                 /* Display message only if NOT in include mode */
                 if (self::checkInclusionStatus($net) != 1)
-                    message::add("Abeille", $eqLogic->getHumanName().": a quitté le réseau => désactivé.", '');
+                    message::add("Abeille", $eqLogic->getHumanName() . ": a quitté le réseau => désactivé.", '');
                 $eqLogic->save();
                 $eqLogic->refresh();
-                log::add('Abeille', 'debug', '  '.$eqLogic->getHumanName().' has left the network => DISABLED');
+                log::add('Abeille', 'debug', '  ' . $eqLogic->getHumanName() . ' has left the network => DISABLED');
 
                 Abeille::updateTimestamp($eqLogic, $msg['time'], $msg['lqi']);
             } else
-                log::add('Abeille', 'debug', 'msgFromParser(): WARNING: Device with IEEE '.$ieee.' NOT found in Jeedom');
+                log::add('Abeille', 'debug', 'msgFromParser(): WARNING: Device with IEEE ' . $ieee . ' NOT found in Jeedom');
 
             return;
         } // End 'leaveIndication'
@@ -2093,20 +2126,20 @@ class Abeille extends eqLogic {
             */
 
             if ($msg['type'] == "attributesReportN")
-                log::add('Abeille', 'debug', "msgFromParser(): Attributes report by name from '".$net."/".$addr."/".$ep);
+                log::add('Abeille', 'debug', "msgFromParser(): Attributes report by name from '" . $net . "/" . $addr . "/" . $ep);
             else
-                log::add('Abeille', 'debug', "msgFromParser(): Read attributes response by name from '".$net."/".$addr."/".$ep);
+                log::add('Abeille', 'debug', "msgFromParser(): Read attributes response by name from '" . $net . "/" . $addr . "/" . $ep);
 
-            $eqLogic = eqLogic::byLogicalId($net.'/'.$addr, 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . '/' . $addr, 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  Unknown device '".$net."/".$addr."'");
+                log::add('Abeille', 'debug', "  Unknown device '" . $net . "/" . $addr . "'");
                 return; // Unknown device
             }
 
             foreach ($msg['attributes'] as $attr) {
                 $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $attr['name']);
                 if (!is_object($cmdLogic)) {
-                    log::add('Abeille', 'debug', "  Unknown Jeedom command logicId='".$attr['name']."'");
+                    log::add('Abeille', 'debug', "  Unknown Jeedom command logicId='" . $attr['name'] . "'");
                 } else {
                     $cmdName = $cmdLogic->getName();
                     $unit = $cmdLogic->getUnite();
@@ -2115,9 +2148,9 @@ class Abeille extends eqLogic {
                     // WARNING: value might not be the final one if 'calculValueOffset' is used
                     $cvo = $cmdLogic->getConfiguration('calculValueOffset', '');
                     if ($cvo == '')
-                        log::add('Abeille', 'debug', "  '".$cmdName."' (".$attr['name'].") => ".$attr['value']." ".$unit);
+                        log::add('Abeille', 'debug', "  '" . $cmdName . "' (" . $attr['name'] . ") => " . $attr['value'] . " " . $unit);
                     else
-                        log::add('Abeille', 'debug', "  '".$cmdName."' (".$attr['name'].") => ".$attr['value']." (calculValueOffset=".$cvo.")");
+                        log::add('Abeille', 'debug', "  '" . $cmdName . "' (" . $attr['name'] . ") => " . $attr['value'] . " (calculValueOffset=" . $cvo . ")");
                     $eqLogic->checkAndUpdateCmd($cmdLogic, $attr['value']);
 
                     // Check if any action cmd must be executed triggered by this update
@@ -2144,32 +2177,32 @@ class Abeille extends eqLogic {
                 'time' => time()
             ); */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", Zigate version ".$msg['major']."-".$msg['minor']);
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", Zigate version " . $msg['major'] . "-" . $msg['minor']);
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
 
             $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), 'FW-Version');
             if ($cmdLogic) {
                 $savedVersion = $cmdLogic->execCmd(); // MMMM-mmmm
-                $version = $msg['major'].'-'.$msg['minor'];
+                $version = $msg['major'] . '-' . $msg['minor'];
                 if ($savedVersion != $version)
-                    log::add('Abeille', 'debug', '  FW saved version: '.$savedVersion);
+                    log::add('Abeille', 'debug', '  FW saved version: ' . $savedVersion);
                 if ($savedVersion == '---------') {
                     $zgId = substr($net, 7);
                     if (hexdec($msg['minor']) >= 0x031D) {
-                        log::add('Abeille', 'debug', '  FW version >= 3.1D => Configuring zigate '.$zgId.' in hybrid mode');
-                        Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/setZgMode", "mode=hybrid");
+                        log::add('Abeille', 'debug', '  FW version >= 3.1D => Configuring zigate ' . $zgId . ' in hybrid mode');
+                        Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/setZgMode", "mode=hybrid");
                     } else {
-                        log::add('Abeille', 'debug', '  Old FW. Configuring zigate '.$zgId.' in normal mode');
-                        Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille".$zgId."/0000/setZgMode", "mode=normal");
+                        log::add('Abeille', 'debug', '  Old FW. Configuring zigate ' . $zgId . ' in normal mode');
+                        Abeille::publishMosquitto($abQueues['xToCmd']['id'], priorityInterrogation, "CmdAbeille" . $zgId . "/0000/setZgMode", "mode=normal");
                     }
                     // TODO: Different msg according to v1 or v2
                     if (hexdec($msg['minor']) < 0x0321) {
                         if (hexdec($msg['minor']) < 0x031E)
-                            message::add('Abeille', 'Attention: La zigate '.$zgId.' fonctionne avec un trop vieux FW incompatible avec Abeille. Merci de faire une mise-à-jour en 3.21 ou supérieur.');
+                            message::add('Abeille', 'Attention: La zigate ' . $zgId . ' fonctionne avec un trop vieux FW incompatible avec Abeille. Merci de faire une mise-à-jour en 3.21 ou supérieur.');
                         else
                             message::add('Abeille', "Il est recommandé de mettre à jour votre Zigate avec la version '3.21'.");
                     }
@@ -2192,10 +2225,10 @@ class Abeille extends eqLogic {
                 'time' => time()
              */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", Zigate timeServer ".$msg['time']);
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", Zigate timeServer " . $msg['time']);
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
             $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), 'ZiGate-Time');
@@ -2217,10 +2250,10 @@ class Abeille extends eqLogic {
                 'time' => time()
              */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", Zigate power ".$msg['power']);
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", Zigate power " . $msg['power']);
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
             $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), 'ZiGate-Power');
@@ -2247,13 +2280,13 @@ class Abeille extends eqLogic {
                 'time' => time()
             ); */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", network state, ieee=".$msg['ieee'].", chan=".$msg['chan']);
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", network state, ieee=" . $msg['ieee'] . ", chan=" . $msg['chan']);
 
             Abeille::checkZgIeee($net, $msg['ieee']);
 
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
             // $ieee = $eqLogic->getConfiguration('IEEE', '');
@@ -2298,18 +2331,18 @@ class Abeille extends eqLogic {
                 'time' => time()
             ); */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", network started, ieee=".$msg['ieee'].", chan=".$msg['chan']);
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", network started, ieee=" . $msg['ieee'] . ", chan=" . $msg['chan']);
 
             Abeille::checkZgIeee($net, $msg['ieee']);
 
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
             $ieee = $eqLogic->getConfiguration('IEEE', '');
             if (($ieee != '') && ($ieee != $msg['ieee'])) {
-                log::add('Abeille', 'debug', "  ERROR: IEEE mistmatch, got ".$msg['ieee']." while expecting ".$ieee);
+                log::add('Abeille', 'debug', "  ERROR: IEEE mistmatch, got " . $msg['ieee'] . " while expecting " . $ieee);
                 return;
             }
             $eqId = $eqLogic->getId();
@@ -2335,10 +2368,10 @@ class Abeille extends eqLogic {
                 'time' => time()
             ); */
 
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net.", permit join, status=".$msg['status']);
-            $eqLogic = eqLogic::byLogicalId($net."/0000", 'Abeille');
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . ", permit join, status=" . $msg['status']);
+            $eqLogic = eqLogic::byLogicalId($net . "/0000", 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  ERROR: No zigate for network ".$net);
+                log::add('Abeille', 'debug', "  ERROR: No zigate for network " . $net);
                 return;
             }
             $eqId = $eqLogic->getId();
@@ -2359,9 +2392,9 @@ class Abeille extends eqLogic {
             // 'status' => $status,
             // 'time' => time(),
             // 'lqi' => $lqi,
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net."/".$addr.", Bind response, status=".$msg['status']);
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . "/" . $addr . ", Bind response, status=" . $msg['status']);
 
-            $eqLogic = eqLogic::byLogicalId($net.'/'.$addr, 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . '/' . $addr, 'Abeille');
             if ($eqLogic)
                 Abeille::updateTimestamp($eqLogic, $msg['time'], $msg['lqi']);
 
@@ -2376,9 +2409,9 @@ class Abeille extends eqLogic {
             // 'ieee' => $ieee,
             // 'time' => time(),
             // 'lqi' => $lqi,
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net."/".$addr.", IEEE addr response, ieee=".$msg['ieee']);
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . "/" . $addr . ", IEEE addr response, ieee=" . $msg['ieee']);
 
-            $eqLogic = eqLogic::byLogicalId($net.'/'.$addr, 'Abeille');
+            $eqLogic = eqLogic::byLogicalId($net . '/' . $addr, 'Abeille');
             if (!$eqLogic) {
                 log::add('Abeille', 'debug', "  WARNING: Unknown device");
                 return;
@@ -2407,10 +2440,10 @@ class Abeille extends eqLogic {
             // 'groups' => $grp
             // 'time' => time(),
             // 'lqi' => $lqi
-            log::add('Abeille', 'debug', "msgFromParser(): ".$net."/".$addr."/".$ep.", ".$msg['type'].", groups=".$msg['groups']);
-            $eqLogic = eqLogic::byLogicalId($net.'/'.$addr, 'Abeille');
+            log::add('Abeille', 'debug', "msgFromParser(): " . $net . "/" . $addr . "/" . $ep . ", " . $msg['type'] . ", groups=" . $msg['groups']);
+            $eqLogic = eqLogic::byLogicalId($net . '/' . $addr, 'Abeille');
             if (!is_object($eqLogic)) {
-                log::add('Abeille', 'debug', "  Unknown device '".$net."/".$addr."'");
+                log::add('Abeille', 'debug', "  Unknown device '" . $net . "/" . $addr . "'");
                 return; // Unknown device
             }
 
@@ -2427,7 +2460,7 @@ class Abeille extends eqLogic {
                 if ($groups == '')
                     $groups = $msg['groups'];
                 else
-                    $groups .= '/'.$msg['groups'];
+                    $groups .= '/' . $msg['groups'];
             } else { // removeGroupResponse
                 $groupsArr = explode("/", $groups);
                 foreach ($groupsArr as $gIdx => $g) {
@@ -2446,15 +2479,16 @@ class Abeille extends eqLogic {
             return;
         } // End 'addGroupResponse'/'removeGroupResponse'/'getGroupMembershipResponse'
 
-        log::add('Abeille', 'debug', "msgFromParser(): Ignored msg ".json_encode($msg));
+        log::add('Abeille', 'debug', "msgFromParser(): Ignored msg " . json_encode($msg));
     } // End msgFromParser()
 
-    public static function publishMosquitto($queueId, $priority, $topic, $payload) {
+    public static function publishMosquitto($queueId, $priority, $topic, $payload)
+    {
         static $queueStatus = []; // "ok" or "error"
 
         $queue = msg_get_queue($queueId);
         if ($queue === false) {
-            log::add('Abeille', 'error', "publishMosquitto(): La queue ".$queueId." n'existe pas. Message ignoré.");
+            log::add('Abeille', 'error', "publishMosquitto(): La queue " . $queueId . " n'existe pas. Message ignoré.");
             return;
         }
         if (($stat = msg_stat_queue($queue)) == false) {
@@ -2466,7 +2500,7 @@ class Abeille extends eqLogic {
            Note: Assuming potential pb if more than 50 pending messages. */
         $pendMsg = $stat['msg_qnum']; // Pending messages
         if ($pendMsg > 50) {
-            if (file_exists("/proc/") && !file_exists("/proc/".$stat['msg_lrpid'])) {
+            if (file_exists("/proc/") && !file_exists("/proc/" . $stat['msg_lrpid'])) {
                 /* Receiver process seems down */
                 if (isset($queueStatus[$queueId]) && ($queueStatus[$queueId] == "error"))
                     return; // Queue already marked "in error"
@@ -2484,20 +2518,21 @@ class Abeille extends eqLogic {
         $msgJson = json_encode($msg);
 
         if (msg_send($queue, $priority, $msgJson, false, false, $error_code)) {
-            log::add('Abeille', 'debug', "  publishMosquitto(): Envoyé '".$msgJson."' vers queue ".$queueId);
+            log::add('Abeille', 'debug', "  publishMosquitto(): Envoyé '" . $msgJson . "' vers queue " . $queueId);
             $queueStatus[$queueId] = "ok"; // Status ok
         } else
-            log::add('Abeille', 'warning', "publishMosquitto(): Impossible d'envoyer '".$msgJson."' vers queue ".$queueId);
+            log::add('Abeille', 'warning', "publishMosquitto(): Impossible d'envoyer '" . $msgJson . "' vers queue " . $queueId);
     } // End publishMosquitto()
 
-    public static function msgToCmd($priority, $topic, $payload = "") {
+    public static function msgToCmd($priority, $topic, $payload = "")
+    {
         static $queueStatus = []; // "ok" or "error"
 
         $abQueues = $GLOBALS['abQueues'];
         $queueId = $abQueues['xToCmd']['id'];
         $queue = msg_get_queue($queueId);
         if ($queue === false) {
-            log::add('Abeille', 'error', "msgToCmd(): La queue ".$queueId." n'existe pas => Message ignoré.");
+            log::add('Abeille', 'error', "msgToCmd(): La queue " . $queueId . " n'existe pas => Message ignoré.");
             return;
         }
         if (($stat = msg_stat_queue($queue)) == false) {
@@ -2509,7 +2544,7 @@ class Abeille extends eqLogic {
            Note: Assuming potential pb if more than 50 pending messages. */
         $pendMsg = $stat['msg_qnum']; // Pending messages
         if ($pendMsg > 50) {
-            if (file_exists("/proc/") && !file_exists("/proc/".$stat['msg_lrpid'])) {
+            if (file_exists("/proc/") && !file_exists("/proc/" . $stat['msg_lrpid'])) {
                 /* Receiver process seems down */
                 if (isset($queueStatus[$queueId]) && ($queueStatus[$queueId] == "error"))
                     return; // Queue already marked "in error"
@@ -2527,22 +2562,23 @@ class Abeille extends eqLogic {
         $msgJson = json_encode($msg);
 
         if (msg_send($queue, $priority, $msgJson, false, false, $error_code)) {
-            log::add('Abeille', 'debug', "  msgToCmd(): Envoyé '".$msgJson."' vers queue ".$queueId);
+            log::add('Abeille', 'debug', "  msgToCmd(): Envoyé '" . $msgJson . "' vers queue " . $queueId);
             $queueStatus[$queueId] = "ok"; // Status ok
         } else
-            log::add('Abeille', 'warning', "msgToCmd(): Impossible d'envoyer '".$msgJson."' vers queue ".$queueId);
+            log::add('Abeille', 'warning', "msgToCmd(): Impossible d'envoyer '" . $msgJson . "' vers queue " . $queueId);
     } // End msgToCmd()
 
     // Beehive creation/update function. Called on daemon startup or new beehive creation.
-    public static function createRuche($dest) {
-        $eqLogic = eqLogic::byLogicalId($dest."/0000", 'Abeille');
+    public static function createRuche($dest)
+    {
+        $eqLogic = eqLogic::byLogicalId($dest . "/0000", 'Abeille');
         if (!is_object($eqLogic)) {
             message::add("Abeille", "Création de l'équipement 'Ruche' en cours. Rafraichissez votre dashboard dans qq secondes.", '');
-            log::add('Abeille', 'info', 'Ruche: Création de '.$dest."/0000");
+            log::add('Abeille', 'info', 'Ruche: Création de ' . $dest . "/0000");
             $eqLogic = new Abeille();
             //id
-            $eqLogic->setName("Ruche-".$dest);
-            $eqLogic->setLogicalId($dest."/0000");
+            $eqLogic->setName("Ruche-" . $dest);
+            $eqLogic->setLogicalId($dest . "/0000");
             $config = AbeilleTools::getConfig();
             if ($config['ab::defaultParent'] > 0) {
                 $eqLogic->setObject_id($config['ab::defaultParent']);
@@ -2550,7 +2586,7 @@ class Abeille extends eqLogic {
                 $eqLogic->setObject_id(jeeObject::rootObject()->getId());
             }
             $eqLogic->setEqType_name('Abeille');
-            $eqLogic->setConfiguration('topic', $dest."/0000");
+            $eqLogic->setConfiguration('topic', $dest . "/0000");
             // $eqLogic->setConfiguration('type', 'topic'); // Tcharp38: What for ?
             // $eqLogic->setConfiguration('lastCommunicationTimeOut', '-1');
             $eqLogic->setIsVisible("0");
@@ -2559,7 +2595,7 @@ class Abeille extends eqLogic {
             $eqLogic->setIsEnable("1");
         } else {
             // TODO: If already exist, should we update commands if required ?
-            log::add('Abeille', 'debug', "createRuche(): '".$eqLogic->getLogicalId()."' already exists");
+            log::add('Abeille', 'debug', "createRuche(): '" . $eqLogic->getLogicalId() . "' already exists");
         }
 
         $eqLogic->setConfiguration('mainEP', '01');
@@ -2578,7 +2614,7 @@ class Abeille extends eqLogic {
         if (!isset($zigbee['groups']))
             $zigbee['groups'] = [];
         if (!isset($zigbee['groups']['01']))
-                $zigbee['groups']['01'] = '';
+            $zigbee['groups']['01'] = '';
         $eqLogic->setConfiguration('ab::zigbee', $zigbee);
 
         $eqLogic->setStatus('lastCommunication', date('Y-m-d H:i:s'));
@@ -2629,7 +2665,7 @@ class Abeille extends eqLogic {
                 }
             }
             if ($found == false) {
-                log::add('Abeille', 'debug', "  Removing cmd '".$cmdName."' => '".$cmdLogicId."'");
+                log::add('Abeille', 'debug', "  Removing cmd '" . $cmdName . "' => '" . $cmdLogicId . "'");
                 $cmdLogic->remove(); // No longer required
             }
         }
@@ -2640,7 +2676,7 @@ class Abeille extends eqLogic {
             $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqLogic->getId(), $cmdLogicId);
             if (!$cmdLogic) {
                 $cmdJName = $mCmd["name"]; // Jeedom cmd name
-                log::add('Abeille', 'debug', "  Adding cmd '".$cmdJName."' => '".$cmdLogicId."'");
+                log::add('Abeille', 'debug', "  Adding cmd '" . $cmdJName . "' => '" . $cmdLogicId . "'");
                 $cmdLogic = new AbeilleCmd();
                 $cmdLogic->setEqLogic_id($eqLogic->getId());
                 $cmdLogic->setEqType('Abeille');
@@ -2649,7 +2685,7 @@ class Abeille extends eqLogic {
                 $newCmd = true;
             } else {
                 $cmdJName = $cmdLogic->getName();
-                log::add('Abeille', 'debug', "  Updating cmd '".$cmdJName."' => '".$cmdLogicId."'");
+                log::add('Abeille', 'debug', "  Updating cmd '" . $cmdJName . "' => '" . $cmdLogicId . "'");
                 $newCmd = false;
             }
 
@@ -2708,15 +2744,16 @@ class Abeille extends eqLogic {
     } // End createRuche()
 
     // Create a basic Jeedom device
-    public static function newJeedomDevice($net, $addr, $ieee) {
-        log::add('Abeille', 'debug', '  newJeedomDevice('.$net.', addr='.$addr.')');
+    public static function newJeedomDevice($net, $addr, $ieee)
+    {
+        log::add('Abeille', 'debug', '  newJeedomDevice(' . $net . ', addr=' . $addr . ')');
 
-        $logicalId = $net.'/'.$addr;
+        $logicalId = $net . '/' . $addr;
         $eqLogic = new Abeille();
         $eqLogic->setEqType_name('Abeille');
-        $eqLogic->setName("newDevice-".$addr); // Temp name to have it non empty
+        $eqLogic->setName("newDevice-" . $addr); // Temp name to have it non empty
         $eqLogic->save(); // Save to force Jeedom to assign an ID
-        $eqName = $net."-".$eqLogic->getId(); // Default name (ex: 'Abeille1-12')
+        $eqName = $net . "-" . $eqLogic->getId(); // Default name (ex: 'Abeille1-12')
         $eqLogic->setName($eqName);
         $eqLogic->setLogicalId($logicalId);
         $abeilleConfig = AbeilleTools::getConfig();
@@ -2733,8 +2770,9 @@ class Abeille extends eqLogic {
        - To create/update a virtual 'remotecontrol' => action = 'update'
        - To update from JSON (identical to re-inclusion) => action = 'update'
      */
-    public static function createDevice($action, $dev) {
-        log::add('Abeille', 'debug', 'createDevice('.$action.', dev='.json_encode($dev));
+    public static function createDevice($action, $dev)
+    {
+        log::add('Abeille', 'debug', 'createDevice(' . $action . ', dev=' . json_encode($dev));
 
         /* $action reminder
               'update' => create or update device (device announce/update)
@@ -2748,8 +2786,8 @@ class Abeille extends eqLogic {
                 );
          */
 
-        $jsonId = (isset($dev['jsonId']) ? $dev['jsonId']: '');
-        $jsonLocation = (isset($dev['jsonLocation']) ? $dev['jsonLocation']: '');
+        $jsonId = (isset($dev['jsonId']) ? $dev['jsonId'] : '');
+        $jsonLocation = (isset($dev['jsonLocation']) ? $dev['jsonLocation'] : '');
         if ($jsonLocation == '')
             $jsonLocation = 'Abeille';
         if ($jsonId != '' && $jsonLocation != '') {
@@ -2758,11 +2796,11 @@ class Abeille extends eqLogic {
                 // log::add('Abeille', 'error', "  createDevice(jsonId=".$jsonId.", location=".$jsonLocation."): Unknown model");
                 return;
             }
-            log::add('Abeille', 'debug', '  Model='.json_encode($model, JSON_UNESCAPED_SLASHES));
+            log::add('Abeille', 'debug', '  Model=' . json_encode($model, JSON_UNESCAPED_SLASHES));
             $modelType = $model['type'];
         }
 
-        $eqLogicId = $dev['net'].'/'.$dev['addr'];
+        $eqLogicId = $dev['net'] . '/' . $dev['addr'];
         $eqLogic = eqLogic::byLogicalId($eqLogicId, 'Abeille');
         if (!is_object($eqLogic)) {
             $newEq = true;
@@ -2773,19 +2811,19 @@ class Abeille extends eqLogic {
             // }
 
             // $action == 'create'
-            log::add('Abeille', 'debug', '  New device '.$eqLogicId);
+            log::add('Abeille', 'debug', '  New device ' . $eqLogicId);
             if ($jsonId != "defaultUnknown")
-                message::add("Abeille", "Nouvel équipement identifié (".$modelType."). Création en cours. Rafraîchissez votre dashboard dans qq secondes.", '');
+                message::add("Abeille", "Nouvel équipement identifié (" . $modelType . "). Création en cours. Rafraîchissez votre dashboard dans qq secondes.", '');
             else
-                message::add("Abeille", "Nouvel équipement détecté mais non supporté. Création en cours avec la config par défaut (".$jsonId."). Rafraîchissez votre dashboard dans qq secondes.", '');
+                message::add("Abeille", "Nouvel équipement détecté mais non supporté. Création en cours avec la config par défaut (" . $jsonId . "). Rafraîchissez votre dashboard dans qq secondes.", '');
 
             $eqLogic = new Abeille();
             $eqLogic->setEqType_name('Abeille');
-            $eqLogic->setName("newDevice-".$dev['addr']); // Temp name to have it non empty
+            $eqLogic->setName("newDevice-" . $dev['addr']); // Temp name to have it non empty
             $eqLogic->save(); // Save to force Jeedom to assign an ID
 
             $eqId = $eqLogic->getId();
-            $eqName = $modelType." - ".$eqId; // Default name (ex: '<modeltype> - 12')
+            $eqName = $modelType . " - " . $eqId; // Default name (ex: '<modeltype> - 12')
             $eqLogic->setName($eqName);
             $eqLogic->setLogicalId($eqLogicId);
             $abeilleConfig = AbeilleTools::getConfig();
@@ -2795,7 +2833,7 @@ class Abeille extends eqLogic {
             $newEq = false;
 
             $eqHName = $eqLogic->getHumanName(); // Jeedom hierarchical name
-            log::add('Abeille', 'debug', '  Already existing device '.$eqLogicId.' => '.$eqHName);
+            log::add('Abeille', 'debug', '  Already existing device ' . $eqLogicId . ' => ' . $eqHName);
 
             $jEqModel = $eqLogic->getConfiguration('ab::eqModel', []); // Eq model from Jeedom DB
             $curEqModel = isset($jEqModel['id']) ? $jEqModel['id'] : ''; // Current JSON model
@@ -2803,25 +2841,25 @@ class Abeille extends eqLogic {
             $eqId = $eqLogic->getId();
 
             if ($curEqModel == '') { // Jeedom eq exists but init not completed
-                $eqName = $modelType." - ".$eqId; // Default name (ex: '<modeltype> - 12')
+                $eqName = $modelType . " - " . $eqId; // Default name (ex: '<modeltype> - 12')
                 $eqLogic->setName($eqName);
-                message::add("Abeille", $eqHName.": Nouvel équipement identifié.", '');
+                message::add("Abeille", $eqHName . ": Nouvel équipement identifié.", '');
                 $action = 'reset';
             } else if (($curEqModel == 'defaultUnknown') && ($jsonId != 'defaultUnknown')) {
-                message::add("Abeille", $eqHName.": S'est réannoncé. Mise-à-jour du modèle par défaut vers '".$modelType."'", '');
+                message::add("Abeille", $eqHName . ": S'est réannoncé. Mise-à-jour du modèle par défaut vers '" . $modelType . "'", '');
                 $action = 'reset'; // Update from defaultUnknown = reset to new model
             }
             // else if ($action == "update")
             //     message::add("Abeille", $eqHName.": Mise-à-jour à partir de son modèle (source=".$jsonLocation.")");
             else if ($action == "reset")
-                message::add("Abeille", $eqHName.": Réinitialisation à partir de '".$jsonId."' (source=".$jsonLocation.")");
+                message::add("Abeille", $eqHName . ": Réinitialisation à partir de '" . $jsonId . "' (source=" . $jsonLocation . ")");
             else { // action = create
                 /* Tcharp38: Following https://github.com/KiwiHC16/Abeille/issues/2132#, device re-announce is just ignored here
                     to not generate plenty messages, unless device was disabled.
                     Other reasons to generate message ?
                 */
                 if ($eqLogic->getIsEnable() != 1)
-                    message::add("Abeille", $eqHName.": S'est réannoncé. Mise-à-jour à partir de son modèle (source=".$jsonLocation.")");
+                    message::add("Abeille", $eqHName . ": S'est réannoncé. Mise-à-jour à partir de son modèle (source=" . $jsonLocation . ")");
             }
 
             // $eqModel = $eqLogic->getConfiguration('ab::eqModel', '');
@@ -2847,14 +2885,14 @@ class Abeille extends eqLogic {
         }
 
         if ($jsonLocation == "local") {
-            $fullPath = __DIR__."/../config/devices/".$jsonId."/".$jsonId.".json";
+            $fullPath = __DIR__ . "/../config/devices/" . $jsonId . "/" . $jsonId . ".json";
             if (file_exists($fullPath))
-                message::add("Abeille", $eqHName.": Attention ! Modèle local (devices_local) utilisé alors qu'un modèle officiel existe.", '');
+                message::add("Abeille", $eqHName . ": Attention ! Modèle local (devices_local) utilisé alors qu'un modèle officiel existe.", '');
         }
 
         /* Whatever creation or update, common steps follows */
         $modelConf = $model["configuration"];
-        log::add('Abeille', 'debug', '  modelConfig='.json_encode($modelConf));
+        log::add('Abeille', 'debug', '  modelConfig=' . json_encode($modelConf));
 
         /* mainEP: Used to define default end point to target, when undefined in command itself (use of '#EP#'). */
         if (isset($modelConf['mainEP'])) {
@@ -2876,13 +2914,13 @@ class Abeille extends eqLogic {
         // Icon updated if no-longer-exists/reset/undefined/defaultUnknown
         $curIcon = $eqLogic->getConfiguration('ab::icon', '');
         if ($curIcon != '') {
-            $iconPath = __DIR__.'/../../images/node_'.$curIcon.'.png';
+            $iconPath = __DIR__ . '/../../images/node_' . $curIcon . '.png';
             $iconExists = file_exists($iconPath);
         } else {
             $iconPath = '';
             $iconExists = false;
         }
-        log::add('Abeille', 'debug', 'LA iconExists='.$iconExists.', path='.$iconPath);
+        log::add('Abeille', 'debug', 'LA iconExists=' . $iconExists . ', path=' . $iconPath);
         if (!$iconExists || ($action == 'reset') || ($curIcon == '') || ($curIcon == 'defaultUnknown')) {
             if (isset($modelConf["icon"]))
                 $icon = $modelConf["icon"];
@@ -2941,10 +2979,10 @@ class Abeille extends eqLogic {
         // Temporary support for 'groupEPx' (to replace #GROUPEPx#)
         // Constant used to define remote control group per EP
         for ($g = 1; $g <= 8; $g++) {
-            if (isset($modelConf['groupEP'.$g]))
-                $eqLogic->setConfiguration('groupEP'.$g, $modelConf['groupEP'.$g]);
+            if (isset($modelConf['groupEP' . $g]))
+                $eqLogic->setConfiguration('groupEP' . $g, $modelConf['groupEP' . $g]);
             else
-                $eqLogic->setConfiguration('groupEP'.$g, null);
+                $eqLogic->setConfiguration('groupEP' . $g, null);
         }
 
         if (isset($modelConf['onTime'])) { // Tcharp38: What for ?
@@ -2973,7 +3011,7 @@ class Abeille extends eqLogic {
             $eqLogic->setConfiguration('ab::customization', $model['customization']);
             if (isset($model['customization']['macCapa'])) {
                 $zigbee['macCapa'] = $model['customization']['macCapa'];
-                log::add('Abeille', 'debug', "  'macCapa' forced to ".$zigbee['macCapa']);
+                log::add('Abeille', 'debug', "  'macCapa' forced to " . $zigbee['macCapa']);
             }
         } else {
             $eqLogic->setConfiguration('ab::customization', null);
@@ -3013,14 +3051,14 @@ class Abeille extends eqLogic {
             $modelCmds2 = json_encode($modelCmds, JSON_UNESCAPED_SLASHES);
             if (strstr($modelCmds2, '#EP#') !== false) {
                 if ($mainEP == "") {
-                    message::add("Abeille", "'mainEP' est requis mais n'est pas défini dans '".$jsonId.".json'", '');
+                    message::add("Abeille", "'mainEP' est requis mais n'est pas défini dans '" . $jsonId . ".json'", '');
                     $mainEP = "01";
                 }
 
-                log::add('Abeille', 'debug', '  mainEP='.$mainEP);
+                log::add('Abeille', 'debug', '  mainEP=' . $mainEP);
                 $modelCmds2 = str_ireplace('#EP#', $mainEP, $modelCmds2);
                 $modelCmds = json_decode($modelCmds2, true);
-                log::add('Abeille', 'debug', '  Updated commands='.json_encode($modelCmds));
+                log::add('Abeille', 'debug', '  Updated commands=' . json_encode($modelCmds));
             }
         }
 
@@ -3043,9 +3081,9 @@ class Abeille extends eqLogic {
             $cmdTopic = $cmdLogic->getConfiguration('topic', '');
             $cmdReq = $cmdLogic->getConfiguration('request', '');
             if ($cmdType == 'info')
-                log::add('Abeille', 'debug', "  Jeedom ".$cmdType.": name='".$cmdName."' ('".$cmdLogicId."'), id=".$cmdId);
+                log::add('Abeille', 'debug', "  Jeedom " . $cmdType . ": name='" . $cmdName . "' ('" . $cmdLogicId . "'), id=" . $cmdId);
             else
-                log::add('Abeille', 'debug', "  Jeedom ".$cmdType.": name='".$cmdName."' ('".$cmdLogicId."'), id=".$cmdId.", topic='".$cmdTopic."', req='".$cmdReq."'");
+                log::add('Abeille', 'debug', "  Jeedom " . $cmdType . ": name='" . $cmdName . "' ('" . $cmdLogicId . "'), id=" . $cmdId . ", topic='" . $cmdTopic . "', req='" . $cmdReq . "'");
             $c = array(
                 'name' => $cmdName,
                 'logicalId' => $cmdLogicId,
@@ -3063,19 +3101,19 @@ class Abeille extends eqLogic {
         foreach ($modelCmds as $mCmdName => $mCmd) {
             // Initial checks
             if (!isset($mCmd["type"])) {
-                log::add('Abeille', 'error', "La commande '".$mCmdName."' n'a pas de 'type' défini => ignorée");
+                log::add('Abeille', 'error', "La commande '" . $mCmdName . "' n'a pas de 'type' défini => ignorée");
                 continue;
             }
             $mCmdType = $mCmd["type"];
             if ($mCmdType == 'info') {
                 if (!isset($mCmd["logicalId"]) || ($mCmd["logicalId"] == '')) {
-                    log::add('Abeille', 'error', "La commande '".$mCmdName."' n'a pas de 'logicalId' défini => ignorée");
+                    log::add('Abeille', 'error', "La commande '" . $mCmdName . "' n'a pas de 'logicalId' défini => ignorée");
                     continue;
                 }
             } else if ($mCmdType == 'action') {
                 // Any checks ?
             } else {
-                log::add('Abeille', 'error', "La commande '".$mCmdName."' a un type invalide (".$mCmdType.") => ignorée");
+                log::add('Abeille', 'error', "La commande '" . $mCmdName . "' a un type invalide (" . $mCmdType . ") => ignorée");
                 continue;
             }
 
@@ -3095,7 +3133,7 @@ class Abeille extends eqLogic {
             $cmdId = null;
 
             // Search by logical ID
-            log::add('Abeille', 'debug', "  Searching by logical ID: '".$mCmdLogicId."'");
+            log::add('Abeille', 'debug', "  Searching by logical ID: '" . $mCmdLogicId . "'");
             foreach ($jeedomCmds as $jCmdId => $jCmd) {
                 // Note: Cmd logical ID & names have to be unique
                 // if (($jCmd['logicalId'] != $mCmdLogicId) && ($jCmd['name'] != $mCmdName))
@@ -3109,7 +3147,7 @@ class Abeille extends eqLogic {
 
             // Search by name if still not found
             if ($cmdId === null) {
-                log::add('Abeille', 'debug', "  Searching by name: '".$mCmdName."'");
+                log::add('Abeille', 'debug', "  Searching by name: '" . $mCmdName . "'");
                 foreach ($jeedomCmds as $jCmdId => $jCmd) {
                     if (($jCmd['name'] != '') && ($jCmd['name'] != $mCmdName))
                         continue;
@@ -3123,7 +3161,7 @@ class Abeille extends eqLogic {
             if (($cmdId === null) && ($mCmdType == 'action')) {
                 $mTopic = $mCmd["configuration"]['topic'];
                 $mRequest = $mCmd["configuration"]['request'];
-                log::add('Abeille', 'debug', "  Searching by topic/request='".$mTopic."/".$mRequest."'");
+                log::add('Abeille', 'debug', "  Searching by topic/request='" . $mTopic . "/" . $mRequest . "'");
                 foreach ($jeedomCmds as $jCmdId => $jCmd) {
                     if ($jCmd['topic'] != $mTopic)
                         continue;
@@ -3138,22 +3176,22 @@ class Abeille extends eqLogic {
             if ($cmdId === null) { // Not found => new command
                 $newCmd = true;
                 if ($mCmdType == 'info')
-                    log::add('Abeille', 'debug', "  Adding ".$mCmdType." '".$mCmdName."' (".$mCmdLogicId.")");
+                    log::add('Abeille', 'debug', "  Adding " . $mCmdType . " '" . $mCmdName . "' (" . $mCmdLogicId . ")");
                 else
-                    log::add('Abeille', 'debug', "  Adding ".$mCmdType." '".$mCmdName."' (".$mCmdLogicId."), topic='".$mCmdTopic."', request='".$mCmdReq."'");
+                    log::add('Abeille', 'debug', "  Adding " . $mCmdType . " '" . $mCmdName . "' (" . $mCmdLogicId . "), topic='" . $mCmdTopic . "', request='" . $mCmdReq . "'");
                 $cmdLogic = new cmd();
                 $cmdLogic->setEqLogic_id($eqId);
                 $cmdLogic->setEqType('Abeille');
             } else {
                 $newCmd = false;
-                log::add('Abeille', 'debug', '  found: id='.$cmdId);
+                log::add('Abeille', 'debug', '  found: id=' . $cmdId);
                 $cmdLogic = cmd::byId($cmdId);
                 $jCmdName = $cmdLogic->getName();
                 $jCmdLogicId = $cmdLogic->getLogicalId();
                 if ($mCmdType == 'info')
-                    log::add('Abeille', 'debug', "  Updating ".$mCmdType." '".$jCmdName."' (".$jCmdLogicId.")");
+                    log::add('Abeille', 'debug', "  Updating " . $mCmdType . " '" . $jCmdName . "' (" . $jCmdLogicId . ")");
                 else {
-                    log::add('Abeille', 'debug', "  Updating ".$mCmdType." '".$jCmdName."' (".$jCmdLogicId.") => logicId='".$mCmdLogicId."', topic='".$mCmdTopic."', request='".$mCmdReq."'");
+                    log::add('Abeille', 'debug', "  Updating " . $mCmdType . " '" . $jCmdName . "' (" . $jCmdLogicId . ") => logicId='" . $mCmdLogicId . "', topic='" . $mCmdTopic . "', request='" . $mCmdReq . "'");
                     $jeedomCmds[$cmdId]['topic'] = $mCmdTopic;
                     $jeedomCmds[$cmdId]['request'] = $mCmdReq;
                 }
@@ -3197,10 +3235,10 @@ class Abeille extends eqLogic {
                     $cmdLogic->setGeneric_type(null); // Clear generic type
             }
             $curDashbTemplate = $cmdLogic->getTemplate('dashboard', '');
-            log::add('Abeille', 'debug', '  curDashbTemplate='.$curDashbTemplate);
+            log::add('Abeille', 'debug', '  curDashbTemplate=' . $curDashbTemplate);
             if (($action == 'reset') || $newCmd || ($curDashbTemplate == '')) {
                 if (isset($mCmd["template"]) && ($mCmd["template"] != "")) {
-                    log::add('Abeille', 'debug', '  Set dashboard template='.$mCmd["template"]);
+                    log::add('Abeille', 'debug', '  Set dashboard template=' . $mCmd["template"]);
                     $cmdLogic->setTemplate('dashboard', $mCmd["template"]);
                 }
             }
@@ -3215,7 +3253,7 @@ class Abeille extends eqLogic {
             } else { // action cmd
                 if (isset($mCmd["value"])) {
                     // value: pour les commandes action, contient la commande info qui est la valeur actuel de la variable controlée.
-                    log::add('Abeille', 'debug', '  Define cmd info pour cmd action: '.$eqLogic->getHumanName()." - ".$mCmd["value"]);
+                    log::add('Abeille', 'debug', '  Define cmd info pour cmd action: ' . $eqLogic->getHumanName() . " - " . $mCmd["value"]);
 
                     $cmdPointeur_Value = cmd::byTypeEqLogicNameCmdName("Abeille", $eqLogic->getName(), $mCmd["value"]);
                     if ($cmdPointeur_Value)
@@ -3240,7 +3278,7 @@ class Abeille extends eqLogic {
                     // Trick for conversion 'key' => 'ab::key' for Abeille specifics
                     // Note: this is currently not applied to all Abeille specific fields.
                     if (in_array($confKey, $toRename))
-                        $confKey = "ab::".$confKey;
+                        $confKey = "ab::" . $confKey;
 
                     $cmdLogic->setConfiguration($confKey, $confValue);
 
@@ -3302,7 +3340,7 @@ class Abeille extends eqLogic {
         foreach ($jeedomCmds as $jCmdId => $jCmd) {
             if ($jCmd['obsolete'] == False)
                 continue;
-            log::add('Abeille', 'debug', "  Removing info '".$jCmd['name']."' (".$jCmd['logicalId'].")");
+            log::add('Abeille', 'debug', "  Removing info '" . $jCmd['name'] . "' (" . $jCmd['logicalId'] . ")");
             $cmdLogic = cmd::byId($jCmdId);
             $cmdLogic->remove();
         }
@@ -3321,28 +3359,30 @@ class Abeille extends eqLogic {
         );
         Abeille::msgToCmd2($msg);
         Abeille::msgToParser($msg);
-
     } // End createDevice()
 
-    public static function msgToParser($msg) {
+    public static function msgToParser($msg)
+    {
         global $abQueues;
         $queue = msg_get_queue($abQueues['xToParser']['id']);
         $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
         msg_send($queue, 1, $msgJson, false, false);
-        log::add('Abeille', 'debug', "  Msg to Parser: ".$msgJson);
+        log::add('Abeille', 'debug', "  Msg to Parser: " . $msgJson);
     }
 
-    public static function msgToCmd2($msg) {
+    public static function msgToCmd2($msg)
+    {
         global $abQueues;
         $queue = msg_get_queue($abQueues['xToCmd']['id']);
         $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
         msg_send($queue, 1, $msgJson, false, false);
-        log::add('Abeille', 'debug', "  Msg to Cmd: ".$msgJson);
+        log::add('Abeille', 'debug', "  Msg to Cmd: " . $msgJson);
     }
 
     /* Update all infos related to last communication time & LQI of given device.
        This is based on timestamp of last communication received from device itself. */
-    public static function updateTimestamp($eqLogic, $timestamp, $lqi = null) {
+    public static function updateTimestamp($eqLogic, $timestamp, $lqi = null)
+    {
         $eqLogicId = $eqLogic->getLogicalId();
         $eqId = $eqLogic->getId();
 
@@ -3357,33 +3397,33 @@ class Abeille extends eqLogic {
 
         $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, "Time-TimeStamp");
         if (!is_object($cmdLogic))
-            log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: '.$eqLogicId.", missing cmd 'Time-TimeStamp'");
+            log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: ' . $eqLogicId . ", missing cmd 'Time-TimeStamp'");
         else
             $eqLogic->checkAndUpdateCmd($cmdLogic, $timestamp);
 
         $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, "Time-Time");
         if (!is_object($cmdLogic))
-            log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: '.$eqLogicId.", missing cmd 'Time-Time'");
+            log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: ' . $eqLogicId . ", missing cmd 'Time-Time'");
         else
             $eqLogic->checkAndUpdateCmd($cmdLogic, date("Y-m-d H:i:s", $timestamp));
 
         $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, 'online');
         if (is_object($cmdLogic))
-        //     log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: '.$eqLogicId.", missing cmd 'online'");
-        // else
+            //     log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: '.$eqLogicId.", missing cmd 'online'");
+            // else
             $eqLogic->checkAndUpdateCmd($cmdLogic, 1);
 
         if ($lqi != null) {
             $cmdLogic = AbeilleCmd::byEqLogicIdAndLogicalId($eqId, 'Link-Quality');
             if (!is_object($cmdLogic))
-                log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: '.$eqLogicId.", missing cmd 'Link-Quality'");
+                log::add('Abeille', 'debug', '  updateTimestamp(): WARNING: ' . $eqLogicId . ", missing cmd 'Link-Quality'");
             else
                 $eqLogic->checkAndUpdateCmd($cmdLogic, $lqi);
         }
 
         // Updating corresponding Zigate alive status too
         list($net, $addr) = explode("/", $eqLogicId);
-        $zigate = eqLogic::byLogicalId($net.'/0000', 'Abeille');
+        $zigate = eqLogic::byLogicalId($net . '/0000', 'Abeille');
         $zigate->setStatus(array('lastCommunication' => date('Y-m-d H:i:s', $timestamp), 'timeout' => 0));
         // Warning: lastCommunication update is not transmitted not client as not an info cmd
     }

--- a/core/php/AbeilleCliToQueue.php
+++ b/core/php/AbeilleCliToQueue.php
@@ -1,6 +1,6 @@
 <?php
 
-    /* This code purpose is perform actions triggered by client:
+/* This code purpose is perform actions triggered by client:
         - Send a message to a specific queue
             action=sendMsg
             queueId=XXX
@@ -9,271 +9,274 @@
             action=reconfigure&eqId=XX
      */
 
-    /* Tcharp38 note:
+/* Tcharp38 note:
        This file should smoothly replace 'Network/TestSVG/xmlhttpMQTTSend.php'
        but also 'AbeilleFormAction.php' (more work there)
      */
 
-    require_once __DIR__.'/../config/Abeille.config.php'; // dbgFile + queues
+require_once __DIR__ . '/../config/Abeille.config.php'; // dbgFile + queues
 
-    /* Developers mode & PHP errors */
-    if (file_exists(dbgFile)) {
-        $dbgConfig = json_decode(file_get_contents(dbgFile), true);
-        if (isset($dbgConfig["defines"])) {
-            $arr = $dbgConfig["defines"];
-            foreach ($arr as $idx => $value) {
-                if ($value == "Tcharp38")
-                    $dbgTcharp38 = true;
-            }
+/* Developers mode & PHP errors */
+if (file_exists(dbgFile)) {
+    $dbgConfig = json_decode(file_get_contents(dbgFile), true);
+    if (isset($dbgConfig["defines"])) {
+        $arr = $dbgConfig["defines"];
+        foreach ($arr as $idx => $value) {
+            if ($value == "Tcharp38")
+                $dbgTcharp38 = true;
         }
-        /* Dev mode: enabling PHP errors logging */
-        error_reporting(E_ALL);
-        ini_set('error_log', __DIR__.'/../../../../log/AbeillePHP.log');
-        ini_set('log_errors', 'On');
+    }
+    /* Dev mode: enabling PHP errors logging */
+    error_reporting(E_ALL);
+    ini_set('error_log', __DIR__ . '/../../../../log/AbeillePHP.log');
+    ini_set('log_errors', 'On');
+}
+
+require_once __DIR__ . '/../../../../core/php/core.inc.php';
+require_once __DIR__ . '/AbeilleLog.php'; // logDebug()
+
+if (isset($_GET['action']))
+    $action = $_GET['action'];
+else
+    $action = "sendMsg";
+
+if ($action == "sendMsg") {
+    if (isset($dbgTcharp38)) logDebug("CliToQueue: action=" . $action);
+
+    // Default target queue = '$abQueues['xToAbeille']['id']'
+    if (isset($_GET['queueId']))
+        $queueId = $_GET['queueId'];
+    else
+        $queueId = $abQueues['xToAbeille']['id'];
+    if (isset($dbgTcharp38)) logDebug("CliToQueue: queueId=" . $queueId);
+    $queue = msg_get_queue($queueId);
+    if ($queue === false) {
+        if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: Invalid queue ID " . $queueId);
+        return;
     }
 
-    require_once __DIR__.'/../../../../core/php/core.inc.php';
-    require_once __DIR__.'/AbeilleLog.php'; // logDebug()
+    // if (in_array($queueId, [$abQueues['xToAbeille']['id'], $abQueues['xToCmd']['id']])) {
+    //     $topic =  $_GET['topic'];
+    //     $topic = str_replace('_', '/', $topic);
+    //     $payload = $_GET['payload'];
+    //     $payload = str_replace('_', '&', $payload);
+    //     if (isset($dbgTcharp38)) logDebug("CliToQueue: topic=".$topic.", payload=".$payload);
 
-    if (isset($_GET['action']))
-        $action = $_GET['action'];
-    else
-        $action = "sendMsg";
+    //     $msg = array(
+    //         'topic' => $topic,
+    //         'payload' => $payload,
+    //     );
+    //     $msgJson = json_encode($msg);
 
-    if ($action == "sendMsg") {
-        if (isset($dbgTcharp38)) logDebug("CliToQueue: action=".$action);
+    //     if (msg_send($queue, 1, $msgJson, false, false)) {
+    //         echo "(fichier xmlhttpMQQTSend) added to queue: ".$msgJson;
+    //         // print_r(msg_stat_queue($queue));
+    //     } else {
+    //         echo "debug","(fichier xmlhttpMQQTSend) could not add message to queue";
+    //     }
+    // } else {
+    //     if (!isset($_GET['msg'])) {
+    //         if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: 'msg' is undefined");
+    //         return;
+    //     }
+    //     $msgString = $_GET['msg'];
+    //     if (isset($dbgTcharp38)) logDebug("CliToQueue: msg=".$msgString);
+    //     $msgArr = explode('_', $msgString);
+    //     $m = array();
+    //     foreach ($msgArr as $idx => $value) {
+    //         // logDebug("CliToQueue LA: ".$value);
+    //         $a = explode(':', $value);
+    //         $m[$a[0]] = $a[1];
+    //     }
+    //     if (isset($dbgTcharp38)) logDebug("CliToQueue: ".json_encode($m));
+    //     msg_send($queue, 1, json_encode($m), false, false);
+    // }
 
-        // Default target queue = '$abQueues['xToAbeille']['id']'
-        if (isset($_GET['queueId']))
-            $queueId = $_GET['queueId'];
-        else
-            $queueId = $abQueues['xToAbeille']['id'];
-        if (isset($dbgTcharp38)) logDebug("CliToQueue: queueId=".$queueId);
-        $queue = msg_get_queue($queueId);
-        if ($queue === false) {
-            if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: Invalid queue ID ".$queueId);
-            return;
+    if (isset($_GET['msg'])) {
+        $msgString = $_GET['msg'];
+        if (isset($dbgTcharp38)) logDebug("CliToQueue: msg=" . $msgString);
+        $msgArr = explode('_', $msgString);
+        $m = array();
+        foreach ($msgArr as $idx => $value) {
+            // logDebug("CliToQueue LA: ".$value);
+            $a = explode(':', $value);
+            $m[$a[0]] = $a[1];
         }
+        if (isset($dbgTcharp38)) logDebug("CliToQueue: " . json_encode($m));
+        msg_send($queue, 1, json_encode($m), false, false);
+    } else if (isset($_GET['topic'])) {
+        $topic =  $_GET['topic'];
+        $topic = str_replace('_', '/', $topic);
+        $payload = $_GET['payload'];
+        $payload = str_replace('_', '&', $payload);
+        if (isset($dbgTcharp38)) logDebug("CliToQueue: topic=" . $topic . ", payload=" . $payload);
 
-        // if (in_array($queueId, [$abQueues['xToAbeille']['id'], $abQueues['xToCmd']['id']])) {
-        //     $topic =  $_GET['topic'];
-        //     $topic = str_replace('_', '/', $topic);
-        //     $payload = $_GET['payload'];
-        //     $payload = str_replace('_', '&', $payload);
-        //     if (isset($dbgTcharp38)) logDebug("CliToQueue: topic=".$topic.", payload=".$payload);
-
-        //     $msg = array(
-        //         'topic' => $topic,
-        //         'payload' => $payload,
-        //     );
-        //     $msgJson = json_encode($msg);
-
-        //     if (msg_send($queue, 1, $msgJson, false, false)) {
-        //         echo "(fichier xmlhttpMQQTSend) added to queue: ".$msgJson;
-        //         // print_r(msg_stat_queue($queue));
-        //     } else {
-        //         echo "debug","(fichier xmlhttpMQQTSend) could not add message to queue";
-        //     }
-        // } else {
-        //     if (!isset($_GET['msg'])) {
-        //         if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: 'msg' is undefined");
-        //         return;
-        //     }
-        //     $msgString = $_GET['msg'];
-        //     if (isset($dbgTcharp38)) logDebug("CliToQueue: msg=".$msgString);
-        //     $msgArr = explode('_', $msgString);
-        //     $m = array();
-        //     foreach ($msgArr as $idx => $value) {
-        //         // logDebug("CliToQueue LA: ".$value);
-        //         $a = explode(':', $value);
-        //         $m[$a[0]] = $a[1];
-        //     }
-        //     if (isset($dbgTcharp38)) logDebug("CliToQueue: ".json_encode($m));
-        //     msg_send($queue, 1, json_encode($m), false, false);
-        // }
-
-        if (isset($_GET['msg'])) {
-            $msgString = $_GET['msg'];
-            if (isset($dbgTcharp38)) logDebug("CliToQueue: msg=".$msgString);
-            $msgArr = explode('_', $msgString);
-            $m = array();
-            foreach ($msgArr as $idx => $value) {
-                // logDebug("CliToQueue LA: ".$value);
-                $a = explode(':', $value);
-                $m[$a[0]] = $a[1];
-            }
-            if (isset($dbgTcharp38)) logDebug("CliToQueue: ".json_encode($m));
-            msg_send($queue, 1, json_encode($m), false, false);
-        } else if (isset($_GET['topic'])) {
-            $topic =  $_GET['topic'];
-            $topic = str_replace('_', '/', $topic);
-            $payload = $_GET['payload'];
-            $payload = str_replace('_', '&', $payload);
-            if (isset($dbgTcharp38)) logDebug("CliToQueue: topic=".$topic.", payload=".$payload);
-
-            $msg = array(
-                'topic' => $topic,
-                'payload' => $payload,
-            );
-            msg_send($queue, 1, json_encode($msg), false, false);
-        } else
-            logMessage('error', 'CliToQueue: Unexpected msg');
-
-        return;
-    } // End $action == "sendMsg"
-
-    /* Request to reconfigure device.
-       This is done by executing action cmds with 'execAtCreation' flag set. */
-    /* Tcharp38: TODO: Better to put 'reconfigure' functionality inside AbeilleCmd and remove it
-       from here & parser too. */
-    if (($action == "update") || ($action == "reinit")) {
-        if (isset($dbgTcharp38)) logDebug("CliToQueue: action=".$action);
-
-        $eqId = $_GET['eqId'];
-        $eqLogic = eqLogic::byId($eqId);
-        if (!is_object($eqLogic)) {
-            logDebug("CliToQueue: ERROR: Unknown device with ID ".$eqId);
-            return; // ERROR
-        }
-        list($eqNet, $eqAddr) = explode("/", $eqLogic->getLogicalId());
-        $zgId = substr($eqNet, 7); // AbeilleX => X
-        $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
-        if (isset($eqModel['id']) && ($eqModel['id'] != ''))
-            $jsonId = $eqModel['id'];
-        else
-            $jsonId = '';
-        if (isset($eqModel['location']) && ($eqModel['location'] != '') && ($eqModel['location'] != null))
-            $jsonLocation = $eqModel['location'];
-        else
-            $jsonLocation = 'Abeille';
-        if ($jsonId == '') {
-            logDebug("CliToQueue: ERROR: jsonId empty for device ".$eqId);
-            return; // ERROR
-        }
-
-        $sig = $eqLogic->getConfiguration('ab::signature');
-        if ($sig) {
-            $modelId = $sig['modelId'];
-            $manufId = $sig['manufId'];
-        } else {
-            $modelId = "";
-            $manufId = "";
-        }
-        if (($jsonId == "defaultUnknown") && ($modelId != "")) {
-            $jsonId2 = "";
-            $jsonLoc2 = "";
-            $localP = __DIR__."/../../core/config/devices/";
-            $abeilleP = __DIR__."/../../core/config/devices/";
-            if (file_exists($localP.$modelId."_".$manufId."/".$modelId."_".$manufId.".json")) {
-                $jsonId2 = $modelId."_".$manufId;
-                $jsonLoc2 = "local";
-            } else if (file_exists($abeilleP.$modelId."_".$manufId."/".$modelId."_".$manufId.".json")) {
-                $jsonId2 = $modelId."_".$manufId;
-                $jsonLoc2 = "Abeille";
-            } else if (file_exists($localP.$modelId."/".$modelId.".json")) {
-                $jsonId2 = $modelId;
-                $jsonLoc2 = "local";
-            } else if (file_exists($abeilleP.$modelId."/".$modelId.".json")) {
-                $jsonId2 = $modelId;
-                $jsonLoc2 = "Abeille";
-            }
-            if (($jsonId2 != $jsonId) || ($jsonLoc2 != $jsonLocation)) {
-                if (isset($dbgTcharp38)) logDebug("CliToQueue: New jsonId: ".$jsonId2."/".$jsonLoc2);
-                $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
-                $eqModel['id'] = $jsonId2;
-                $eqModel['location'] = $jsonLoc2;
-                $eqLogic->setConfiguration('ab::eqModel', $eqModel);
-                $eqLogic->save();
-                $jsonId = $jsonId2;
-                $jsonLocation = $jsonLoc2;
-            }
-        }
-
-        if ($action == "update") {
-            $msg = array(
-                'topic' => "CmdCreate".$eqNet."/".$eqAddr."/updateFromModel",
-                'payload' => '',
-            );
-        } else { // $action == "reinit"
-            $msg = array(
-                'topic' => "CmdCreate".$eqNet."/".$eqAddr."/resetFromModel",
-                'payload' => '',
-            );
-        }
-        $queue = msg_get_queue($abQueues['xToAbeille']['id']);
-        $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
-        if (isset($dbgTcharp38)) logDebug("CliToQueue: '".$action."' msg to Abeille: ".$msgJson);
-        if (msg_send($queue, 1, $msgJson, false, false) !== true) {
-            logDebug("CliToQueue: ERROR: msg_send(xToAbeille) failed for device ".$eqId);
-            return; // ERROR
-        }
-        sleep(2); // To let Abeille.class time to update DB
-
-        // Inform parser that EQ config has changed => done at end of createDevice()
-        // $queue = msg_get_queue($abQueues['xToParser']['id']);
-        // $msg = array(
-        //     'type' => "eqUpdated",
-        //     'id' => $eqId,
-        // );
-        // if (isset($dbgTcharp38)) logDebug("'eqUpdated' msg to Parser: ".json_encode($msg));
-        // msg_send($queue, 1, json_encode($msg), false, false);
-
-        // $eqConfig = AbeilleTools::getDeviceModel($jsonId, $jsonLocation);
-        // if ($eqConfig === false) {
-        //     if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: No device config");
-        //     return; // ERROR
-        // }
-        // $mainEP = $eqLogic->getConfiguration('mainEP', '');
-        // $ieee = $eqLogic->getConfiguration('IEEE', '');
-        // $zigate = eqLogic::byLogicalId('Abeille'.$zgId.'/0000', 'Abeille');
-        // $zgIeee = $zigate->getConfiguration('IEEE', '');
-
-        // $cmds = $eqConfig['commands'];
-        // if (isset($dbgTcharp38)) logDebug("CliToQueue: cmds=".json_encode($cmds));
-        // foreach ($cmds as $cmdJName => $cmd) {
-        //     if (!isset($cmd['configuration']))
-        //         continue;
-        //     $c = $cmd['configuration'];
-        //     if (!isset($c['execAtCreation']))
-        //         continue;
-
-        //     $topic = 'Cmd'.$eqNet.'/'.$eqAddr.'/'.$c['topic'];
-        //     $request = $c['request'];
-
-        //     // TODO: #EP# defaulted to first EP but should be
-        //     //       defined in cmd use if different target EP
-        //     $request = str_ireplace('#ep#', $mainEP, $request); // Case insensitive
-
-        //     $request = str_ireplace('#ieee#', $ieee, $request); // Case insensitive
-        //     $request = str_ireplace('#addrIeee#', $ieee, $request); // Case insensitive
-
-        //     $request = str_ireplace('#zigateIeee#', $zgIeee, $request); // Case insensitive
-
-        //     $queue = msg_get_queue($abQueues['xToCmd']['id']);
-        //     $msg = array(
-        //         'topic' => $topic,
-        //         'payload' => $request,
-        //     );
-        //     $msgJson = json_encode($msg);
-        //     if (isset($dbgTcharp38)) logDebug("CliToQueue: msg_send(): ".$msgJson);
-        //     if (msg_send($queue, 1, $msgJson, false, false) == false) {
-        //         if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: msg_send()");
-        //     }
-        // }
-
-        // (Re)Configure device
-        $queue = msg_get_queue($abQueues['xToCmd']['id']);
         $msg = array(
-            'type' => 'configureDevice',
-            'net' => $eqNet,
-            'addr' => $eqAddr
+            'topic' => $topic,
+            'payload' => $payload,
         );
-        $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
-        if (isset($dbgTcharp38)) logDebug("CliToQueue: msg to Cmd: ".$msgJson);
-        msg_send($queue, 1, $msgJson, false, false);
+        msg_send($queue, 1, json_encode($msg), false, false);
+    } else
+        logMessage('error', 'CliToQueue: Unexpected msg');
 
-        return;
-    } // End $action == "reconfigure"
+    return;
+} // End $action == "sendMsg"
 
-    if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: Unknown action=".$action);
-?>
+/* Request to reconfigure device.
+       This is done by executing action cmds with 'execAtCreation' flag set. */
+/* Tcharp38: TODO: Better to put 'reconfigure' functionality inside AbeilleCmd and remove it
+       from here & parser too. */
+if (($action == "update") || ($action == "reinit")) {
+    if (isset($dbgTcharp38)) logDebug("CliToQueue: action=" . $action);
+
+    $eqId = $_GET['eqId'];
+    $eqLogic = eqLogic::byId($eqId);
+    if (!is_object($eqLogic)) {
+        logDebug("CliToQueue: ERROR: Unknown device with ID " . $eqId);
+        return; // ERROR
+    }
+    list($eqNet, $eqAddr) = explode("/", $eqLogic->getLogicalId());
+    $zgId = substr($eqNet, 7); // AbeilleX => X
+    $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
+    if (isset($eqModel['id']) && ($eqModel['id'] != ''))
+        $jsonId = $eqModel['id'];
+    else
+        $jsonId = '';
+    if (isset($eqModel['location']) && ($eqModel['location'] != '') && ($eqModel['location'] != null))
+        $jsonLocation = $eqModel['location'];
+    else
+        $jsonLocation = 'Abeille';
+    if ($jsonId == '') {
+        logDebug("CliToQueue: ERROR: jsonId empty for device " . $eqId);
+        return; // ERROR
+    }
+
+    $sig = $eqLogic->getConfiguration('ab::signature');
+    if ($sig) {
+        $modelId = $sig['modelId'];
+        $manufId = $sig['manufId'];
+    } else {
+        $modelId = "";
+        $manufId = "";
+    }
+
+    // Changement automatique du modèle interdit si l'utilisateur l'a choisi lui-même
+    $isManualModel = $eqLogic->getConfiguration('ab::isManualModel', false);
+
+    if (($jsonId == "defaultUnknown") && ($modelId != "") && !$isManualModel) {
+        $jsonId2 = "";
+        $jsonLoc2 = "";
+        $localP = __DIR__ . "/../../core/config/devices/";
+        $abeilleP = __DIR__ . "/../../core/config/devices/";
+        if (file_exists($localP . $modelId . "_" . $manufId . "/" . $modelId . "_" . $manufId . ".json")) {
+            $jsonId2 = $modelId . "_" . $manufId;
+            $jsonLoc2 = "local";
+        } else if (file_exists($abeilleP . $modelId . "_" . $manufId . "/" . $modelId . "_" . $manufId . ".json")) {
+            $jsonId2 = $modelId . "_" . $manufId;
+            $jsonLoc2 = "Abeille";
+        } else if (file_exists($localP . $modelId . "/" . $modelId . ".json")) {
+            $jsonId2 = $modelId;
+            $jsonLoc2 = "local";
+        } else if (file_exists($abeilleP . $modelId . "/" . $modelId . ".json")) {
+            $jsonId2 = $modelId;
+            $jsonLoc2 = "Abeille";
+        }
+        if (($jsonId2 != $jsonId) || ($jsonLoc2 != $jsonLocation)) {
+            if (isset($dbgTcharp38)) logDebug("CliToQueue: New jsonId: " . $jsonId2 . "/" . $jsonLoc2);
+            $eqModel = $eqLogic->getConfiguration('ab::eqModel', []);
+            $eqModel['id'] = $jsonId2;
+            $eqModel['location'] = $jsonLoc2;
+            $eqLogic->setConfiguration('ab::eqModel', $eqModel);
+            $eqLogic->save();
+            $jsonId = $jsonId2;
+            $jsonLocation = $jsonLoc2;
+        }
+    }
+
+    if ($action == "update") {
+        $msg = array(
+            'topic' => "CmdCreate" . $eqNet . "/" . $eqAddr . "/updateFromModel",
+            'payload' => '',
+        );
+    } else { // $action == "reinit"
+        $msg = array(
+            'topic' => "CmdCreate" . $eqNet . "/" . $eqAddr . "/resetFromModel",
+            'payload' => '',
+        );
+    }
+    $queue = msg_get_queue($abQueues['xToAbeille']['id']);
+    $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
+    if (isset($dbgTcharp38)) logDebug("CliToQueue: '" . $action . "' msg to Abeille: " . $msgJson);
+    if (msg_send($queue, 1, $msgJson, false, false) !== true) {
+        logDebug("CliToQueue: ERROR: msg_send(xToAbeille) failed for device " . $eqId);
+        return; // ERROR
+    }
+    sleep(2); // To let Abeille.class time to update DB
+
+    // Inform parser that EQ config has changed => done at end of createDevice()
+    // $queue = msg_get_queue($abQueues['xToParser']['id']);
+    // $msg = array(
+    //     'type' => "eqUpdated",
+    //     'id' => $eqId,
+    // );
+    // if (isset($dbgTcharp38)) logDebug("'eqUpdated' msg to Parser: ".json_encode($msg));
+    // msg_send($queue, 1, json_encode($msg), false, false);
+
+    // $eqConfig = AbeilleTools::getDeviceModel($jsonId, $jsonLocation);
+    // if ($eqConfig === false) {
+    //     if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: No device config");
+    //     return; // ERROR
+    // }
+    // $mainEP = $eqLogic->getConfiguration('mainEP', '');
+    // $ieee = $eqLogic->getConfiguration('IEEE', '');
+    // $zigate = eqLogic::byLogicalId('Abeille'.$zgId.'/0000', 'Abeille');
+    // $zgIeee = $zigate->getConfiguration('IEEE', '');
+
+    // $cmds = $eqConfig['commands'];
+    // if (isset($dbgTcharp38)) logDebug("CliToQueue: cmds=".json_encode($cmds));
+    // foreach ($cmds as $cmdJName => $cmd) {
+    //     if (!isset($cmd['configuration']))
+    //         continue;
+    //     $c = $cmd['configuration'];
+    //     if (!isset($c['execAtCreation']))
+    //         continue;
+
+    //     $topic = 'Cmd'.$eqNet.'/'.$eqAddr.'/'.$c['topic'];
+    //     $request = $c['request'];
+
+    //     // TODO: #EP# defaulted to first EP but should be
+    //     //       defined in cmd use if different target EP
+    //     $request = str_ireplace('#ep#', $mainEP, $request); // Case insensitive
+
+    //     $request = str_ireplace('#ieee#', $ieee, $request); // Case insensitive
+    //     $request = str_ireplace('#addrIeee#', $ieee, $request); // Case insensitive
+
+    //     $request = str_ireplace('#zigateIeee#', $zgIeee, $request); // Case insensitive
+
+    //     $queue = msg_get_queue($abQueues['xToCmd']['id']);
+    //     $msg = array(
+    //         'topic' => $topic,
+    //         'payload' => $request,
+    //     );
+    //     $msgJson = json_encode($msg);
+    //     if (isset($dbgTcharp38)) logDebug("CliToQueue: msg_send(): ".$msgJson);
+    //     if (msg_send($queue, 1, $msgJson, false, false) == false) {
+    //         if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: msg_send()");
+    //     }
+    // }
+
+    // (Re)Configure device
+    $queue = msg_get_queue($abQueues['xToCmd']['id']);
+    $msg = array(
+        'type' => 'configureDevice',
+        'net' => $eqNet,
+        'addr' => $eqAddr
+    );
+    $msgJson = json_encode($msg, JSON_UNESCAPED_SLASHES);
+    if (isset($dbgTcharp38)) logDebug("CliToQueue: msg to Cmd: " . $msgJson);
+    msg_send($queue, 1, $msgJson, false, false);
+
+    return;
+} // End $action == "reconfigure"
+
+if (isset($dbgTcharp38)) logDebug("CliToQueue: ERROR: Unknown action=" . $action);

--- a/desktop/js/Abeille.js
+++ b/desktop/js/Abeille.js
@@ -89,6 +89,13 @@ function refreshAdvEq() {
                 document.getElementById("idManufCode").value =
                     eq.zigbee.manufCode;
 
+            // Info + lien pour rétablir le fonctionnement normal si l'utilisateur a forcé le model
+            if (eq.isManualModel) {
+                var $pRestoreModelAuto = $("<p><stron>{{Vous avez forcé le modèle de cet équipement. }}</strong></p>");
+                var $aRestoreModelAuto = $("<a href=\"#\" id=\"linkRestoreAutoModel\" style=\"text-decoration:underline;\">{{ Rétablir le fonctionnement normal (modèle auto)}}</a>");
+                $pRestoreModelAuto.append($aRestoreModelAuto).insertAfter("#idModelChangeBtn");
+            }
+
             // Show/hide zigate or devices part
             zgPart = document.getElementById("idAdvZigate");
             devPart = document.getElementById("idAdvDevices");
@@ -246,8 +253,8 @@ function createRemote(zgId) {
     xmlhttpMQTTSendTimer.open(
         "GET",
         "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&topic=CmdCreateAbeille" +
-            zgId +
-            "_zigate_createRemote",
+        zgId +
+        "_zigate_createRemote",
         false
     ); // False pour bloquer sur la recuperation du fichier
     xmlhttpMQTTSendTimer.send();
@@ -334,11 +341,11 @@ function removeBeesJeedom(zgId) {
                     xhr.open(
                         "GET",
                         "plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId=" +
-                            js_queueXToParser +
-                            "&msg=type:eqRemoved_net:Abeille" +
-                            zgId +
-                            "_eqList:" +
-                            eqAddrList,
+                        js_queueXToParser +
+                        "&msg=type:eqRemoved_net:Abeille" +
+                        zgId +
+                        "_eqList:" +
+                        eqAddrList,
                         true
                     );
                     xhr.send();
@@ -424,7 +431,7 @@ function setBeesTimeout(zgId) {
     $("#abeilleModal")
         .load(
             "index.php?v=d&plugin=Abeille&modal=setBeesTimeout.abeille&zgId=" +
-                zgId
+            zgId
         )
         .dialog("open");
 }
@@ -459,10 +466,10 @@ function monitorIt(zgId, zgPort) {
         error: function (request, status, error) {
             bootbox.alert(
                 "ERREUR 'monitor' !<br>" +
-                    "status=" +
-                    status +
-                    "<br>error=" +
-                    error
+                "status=" +
+                status +
+                "<br>error=" +
+                error
             );
         },
         success: function (json_res) {
@@ -680,7 +687,7 @@ $("#idRepairBtn").on("click", function () {
     );
     xhttp.send();
 
-    xhttp.onreadystatechange = function () {};
+    xhttp.onreadystatechange = function () { };
 
     // $.ajax({
     //     url: "/plugins/Abeille/core/php/AbeilleRepair.php?eqId=" + eqId,
@@ -717,7 +724,7 @@ $("#idUpdateBtn").on("click", function () {
         xhttp.open(
             "GET",
             "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=update&eqId=" +
-                eqId,
+            eqId,
             false
         );
         xhttp.send();
@@ -751,11 +758,159 @@ $("#idReinitBtn").on("click", function () {
         xhttp.open(
             "GET",
             "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=reinit&eqId=" +
-                eqId,
+            eqId,
             false
         );
         xhttp.send();
     });
+});
+
+
+/**
+ * Changement de modèle (choix manuel du modèle dans la liste des JSON).
+ * @author JB Romain 16/08/2023
+ */
+$("#idModelChangeBtn").on("click", function () {
+    console.log("Demande changement de modèle", curEqId);
+
+    // Ouverture dialog
+    var myPopup = jeeDialog.dialog({
+        id: 'abeille_modelChangePopup',
+        title: '{{Choisir le modèle de votre équipement}}',
+        width: 500,
+        height: 'auto',
+        contentUrl: ''
+    });
+
+    // Le template de contenu est dans Abeille-Eq-Advanced-Device.php
+    var $content = $(myPopup).find(".jeeDialogContent");
+    $content.append($(".abeille-model-change-popup-content").clone().show());
+    var $datalist = $("#abeille-all-models-list");
+
+    // Requete ajax pour remplir la liste des options (= liste des modèles connus)
+    $.ajax({
+        type: "POST",
+        url: "plugins/Abeille/core/ajax/AbeilleModelChange.ajax.php",
+        data: {
+            action: "getModelChoiceList",
+            eqId: curEqId
+        },
+        dataType: "json",
+        global: false,
+        success: function (lstModels) {
+            console.log("réponse ajax getModelChoiceList", lstModels);
+
+            // On remplit la liste de choix (datalist html5)
+
+            Object.values(lstModels).forEach(model => {
+                var str = '';
+                // Signature Zigbee
+                if (typeof (model.manufacturer) == 'string' && model.manufacturer != '') {
+                    str += '[' + model.manufacturer + '] ';
+                }
+
+                if (typeof (model.model) == 'string' && model.model != '' && model.model != '?') {
+                    str += model.model + ' ';
+                }
+
+                // Libellé
+                if (str != '') {
+                    str += '> ';
+                }
+                str += model.type;
+
+                // Identifiant JSON (incluant l'emplacement)
+                str += ' (' + model.jsonLocation + '/' + model.jsonId + '.json)';
+
+                // Ajout à la liste
+                var $opt = $("<option></option>");
+                $opt.attr("value", str);
+                $datalist.append($opt);
+
+                // Remplissage info s'il s'agit du modèle actuellement en vigueur pour l'équipement
+                if (typeof (model.isCurrent) == 'boolean' && model.isCurrent) {
+                    $content.find("span.current-model").html(str);
+                }
+
+            });
+        },
+    });
+
+    // Bouton annuler
+    $content.find(".btn-secondary").on("click", function () {
+        jeeDialog.get('#abeille_modelChangePopup').destroy();
+    });
+
+    // Bouton enregistrer
+    $content.find(".btn-success").on("click", function () {
+        // On vérifie que l'utilisateur a bien choisi un modèle à appliquer
+        var strSaisie = $content.find("input[type=search]").val();
+        if ($datalist.find("option[value=\"" + strSaisie + "\"]").length == 0) {
+            jeeDialog.alert('{{Erreur: vous devez choisir un modèle dans la liste.}}');
+            return;
+        }
+
+        // Demande de confirmation (+ injonction à réveiller l'équipement s'il est sur batterie)
+        var strSuppBatterie = '';
+        if (eqBatteryType != '') {
+            strSuppBatterie = "<br><br><strong>Attention: </strong>{{Comme cet équipement fonctionne sur batterie, vous devez le réveiller immédiatement après avoir cliqué sur OK.}}";
+        }
+        jeeDialog.confirm("{{L'équipement sera reconfiguré à partir du modèle choisi. Souhaitez-vous vraiment appliquer ce modèle ?}}" + strSuppBatterie, function (result) {
+            if (result) {
+                // On ferme la boite de dialog
+                jeeDialog.get('#abeille_modelChangePopup').destroy();
+
+                // Première requête: enregistrer la configuration de l'équipement (choix modèle)
+                $.ajax({
+                    type: "POST",
+                    url: "plugins/Abeille/core/ajax/AbeilleModelChange.ajax.php",
+                    data: {
+                        action: "setModelToDevice",
+                        eqId: curEqId,
+                        modelChoice: strSaisie
+                    },
+                    dataType: "json",
+                    global: false,
+                    success: function () {
+                        // Deuxième requête: réinitialisation de l'équipement à partir de son (nouveau) modèle
+                        // (comme si on avait cliqué sur le bouton mise à jour)
+                        console.log("Simulation clic sur Mise à jour...");
+                        $("#idUpdateBtn").trigger("click");
+                    }
+                });
+            }
+        })
+
+    });
+
+
+});
+
+/**
+ * Lien pour restaurer le modèle "automatique"
+ */
+$("body").on("click", "a#linkRestoreAutoModel", function () {
+    jeeDialog.confirm("{{Actuellement, le modèle utilisé pour configuré l'équipement est celui que vous avez choisi manuellement. Cette action permet de rétablir le fonctionnement normal d'Abeille: le modèle prédéfini sera utilisé pour reconfigurer l'équipement la prochaine fois qu'il se réannoncera.<br><br>Cette action, en elle-même, ne modifie pas la configuration de l'équipement: après avoir cliqué sur OK, patientez quelques secondes, puis forcez l'équipement à se réannoncer (en le débranchant/rebranchant par exemple), ou utilisez la fonction 'Mise à jour'.<br><br>Etes-vous sûr de vouloir annuler le choix manuel du modèle ?}}", function (result) {
+        $.ajax({
+            type: "POST",
+            url: "plugins/Abeille/core/ajax/AbeilleModelChange.ajax.php",
+            data: {
+                action: "disableManualModelForDevice",
+                eqId: curEqId
+            },
+            dataType: "json",
+            global: false,
+            success: function () {
+                // On laisse le temps à l'utilisateur de lire le message avant d'actualiser la page
+                console.log("disableManualModelForDevice OK");
+                setTimeout(function () {
+                    document.location.reload();
+                }, 3000);
+            }
+        });
+    });
+
+    return false; // prevent default
 });
 
 /* Save given Abeille config (=> 'config' DB) */
@@ -771,7 +926,7 @@ function saveConfig(config) {
         },
         dataType: "json",
         global: false,
-        success: function (json_res) {},
+        success: function (json_res) { },
     });
 }
 
@@ -1042,10 +1197,10 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
             selected.forEach((eq) => {
                 sendCmd(
                     "CmdAbeille" +
-                        eq["zgId"] +
-                        "/" +
-                        eq["addr"] +
-                        "/getGroupMembership",
+                    eq["zgId"] +
+                    "/" +
+                    eq["addr"] +
+                    "/getGroupMembership",
                     "ep=" + eq["mainEp"]
                 );
                 setTimeout(function () {
@@ -1067,10 +1222,10 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
                 setTimeout(function () {
                     sendCmd(
                         "CmdAbeille" +
-                            eq["zgId"] +
-                            "/" +
-                            eq["addr"] +
-                            "/getGroupMembership",
+                        eq["zgId"] +
+                        "/" +
+                        eq["addr"] +
+                        "/getGroupMembership",
                         "ep=" + eq["mainEp"]
                     );
                     location.reload(true);
@@ -1087,19 +1242,19 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
                 sendCmd(
                     "CmdAbeille" + eq["zgId"] + "/0000/removeGroup",
                     "address=" +
-                        eq["addr"] +
-                        "&DestinationEndPoint=" +
-                        eq["mainEp"] +
-                        "&groupAddress=" +
-                        group
+                    eq["addr"] +
+                    "&DestinationEndPoint=" +
+                    eq["mainEp"] +
+                    "&groupAddress=" +
+                    group
                 );
                 setTimeout(function () {
                     sendCmd(
                         "CmdAbeille" +
-                            eq["zgId"] +
-                            "/" +
-                            eq["addr"] +
-                            "/getGroupMembership",
+                        eq["zgId"] +
+                        "/" +
+                        eq["addr"] +
+                        "/getGroupMembership",
                         "ep=" + eq["mainEp"]
                     );
                     location.reload(true);
@@ -1126,11 +1281,11 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
             sendCmd(
                 "CmdAbeille" + zgId + "/" + addr + "/removeGroup",
                 "address=" +
-                    addr +
-                    "&DestinationEndPoint=" +
-                    ep +
-                    "&groupAddress=" +
-                    group
+                addr +
+                "&DestinationEndPoint=" +
+                ep +
+                "&groupAddress=" +
+                group
             );
             setTimeout(function () {
                 location.reload(true);
@@ -1166,10 +1321,10 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
                 setTimeout(function () {
                     sendCmd(
                         "CmdAbeille" +
-                            eq["zgId"] +
-                            "/" +
-                            eq["addr"] +
-                            "/getGroupMembership",
+                        eq["zgId"] +
+                        "/" +
+                        eq["addr"] +
+                        "/getGroupMembership",
                         "ep=" + eq["mainEp"]
                     );
                     location.reload(true);
@@ -1185,17 +1340,17 @@ function sendToCmd(action, param1 = "", param2 = "", param3 = "", param4 = "") {
                 console.log("eq=", eq);
                 sendCmd(
                     "CmdAbeille" +
-                        eq["zgId"] +
-                        "/0000/commissioningGroupAPSLegrand",
+                    eq["zgId"] +
+                    "/0000/commissioningGroupAPSLegrand",
                     "address=" + eq["addr"] + "&groupId=" + group
                 );
                 setTimeout(function () {
                     sendCmd(
                         "CmdAbeille" +
-                            eq["zgId"] +
-                            "/" +
-                            eq["addr"] +
-                            "/getGroupMembership",
+                        eq["zgId"] +
+                        "/" +
+                        eq["addr"] +
+                        "/getGroupMembership",
                         "ep=" + eq["mainEp"]
                     );
                     location.reload(true);
@@ -1546,16 +1701,16 @@ function interrogate(request) {
     xhttp.open(
         "GET",
         "/plugins/Abeille/core/php/AbeilleCliToQueue.php?action=sendMsg&queueId=" +
-            js_queueXToCmd +
-            "&topic=" +
-            topic +
-            "&payload=" +
-            payload,
+        js_queueXToCmd +
+        "&topic=" +
+        topic +
+        "&payload=" +
+        payload,
         false
     );
     xhttp.send();
 
-    xhttp.onreadystatechange = function () {};
+    xhttp.onreadystatechange = function () { };
 }
 
 // addCmdToTable() to be moved there when compliant

--- a/desktop/php/Abeille-Eq-Advanced-Device.php
+++ b/desktop/php/Abeille-Eq-Advanced-Device.php
@@ -4,7 +4,7 @@
 <hr>
 
 <?php
-    if (isset($dbgDeveloperMode)) echo __FILE__;
+if (isset($dbgDeveloperMode)) echo __FILE__;
 ?>
 
 <div class="form-group">
@@ -15,128 +15,49 @@
     </div>
 </div>
 
-<!-- < ?php   TODO: MUST NE IMPLEMENTED in javascript
-    // Tcharp38 note: Most of the devices have only 1 signature but some have several
-    if (isset($eqZigbee['endPoints'])) {
-        $endPoints = $eqZigbee['endPoints'];
-        $manuf = '';
-        $model = '';
-        $location = '';
-        foreach ($endPoints as $epId2 => $ep2) {
-            if (!isset($ep2['servClusters']))
-                continue;
-            if (strpos($ep2['servClusters'], '0000') === false)
-                continue; // Basic cluster not supported
-
-            echo '<div class="form-group">';
-            echo '<label class="col-sm-3 control-label">Identifiant Zigbee EP '.$epId2.'</label>';
-            echo '<div class="col-sm-5">';
-
-                $model2 = isset($ep2['modelId']) ? $ep2['modelId'] : '';
-                $manuf2 = isset($ep2['manufId']) ? $ep2['manufId'] : '';
-                $location2 = isset($ep2['location']) ? $ep2['location'] : '';
-                if (($manuf2 != $manuf) || ($model2 != $model) || ($location2 != $location) ) {
-                    echo '<input readonly title="{{Modèle}}" value="'.$model2.'" />';
-                    echo '<input readonly style="margin-left: 8px" title="{{Fabricant}}" value="'.$manuf2.'" />';
-                    echo '<input readonly style="margin-left: 8px" title="{{Localisation}}" value="'.$location2.'" />';
-                    if ($manuf == '')
-                        $manuf = $manuf2; // Saving 1st
-                    if ($model == '')
-                        $model = $model2; // Saving 1st
-                    if ($location == '')
-                        $location = $location2; // Saving 1st
-                }
-
-            echo '</div>';
-            echo '</div>';
-        }
-    }
-?> -->
-
 <div class="form-group">
     <label class="col-sm-3 control-label">{{Modèle d'équipement}}</label>
-    <div class="col-sm-5">
-        <!-- < ?php
-            if (isset($eqModel['id']))
-                $jsonId = $eqModel['id'];
-            else
-                $jsonId = '';
-            if (isset($eqModel['id']) && ($eqModel['location'] != ''))
-                $jsonLocation = $eqModel['location'];
-            else
-                $jsonLocation = 'Abeille';
+    <div class="col-sm-9">
+        <input id="idModelName" readonly style="width: 200px" title="{{Nom du modèle utilisé}}" value="" />
+        <input id="idModelSource" readonly style="width:86px" title="{{Origine du modèle}}" value="" />
+        <a class="btn btn-warning" id="idUpdateBtn" style="margin-left:8px" title="{{Mise-à-jour à partir de son modèle et reconfiguration}}">{{Mise-à-jour}}</a>
+        <a class="btn btn-danger" id="idReinitBtn" style="margin-left:8px" title="{{Réinitlialise les paramètres par défaut et reconfigure l\'équipement comme s\'il s\'agissait d\'une nouvelle inclusion}}">{{Réinitialiser}}</a>
+        <a class="btn btn-danger" id="idModelChangeBtn" style="margin-left:8px" title="{{Utilisateurs avancés - Choisissez un modèle dans la liste}}">{{Choisir manuellement le modèle}}</a>
 
-            echo '<input readonly style="width: 200px" title="{{Nom du modèle utilisé}}" value="'.$jsonId.'" />';
-            echo '    Source:';
-            if (($jsonLocation == '') || ($jsonLocation == "Abeille"))
-                $title = "Le modèle utilisé est celui fourni par Abeille";
-            else
-                $title = "Le modèle utilisé est un modèle local/custom";
-            echo '<input readonly style="width:86px" title="{{'.$title.'}}" value="'.$jsonLocation.'" />';
-
-            if ($jsonId == "defaultUnknown") {
-                if ($sig) {
-                    $id1 = $sig['modelId'].'_'.$sig['manufId'];
-                    $id2 = $sig['modelId'];
-                    $customP = __DIR__."/../../core/config/devices_local/";
-                    $officialP = __DIR__."/../../core/config/devices/";
-                    if (file_exists($customP.$id1."/".$id1.".json") ||
-                        file_exists($customP.$id2."/".$id2.".json")) {
-                        echo '<span style="background-color:red;color:black" title=""> INFO: Modèle local/custom disponible.</span>';
-                        // echo '<a class="btn btn-warning" onclick="reinit(\''.$eqId.'\')" title="Réinitlialisation avec le modèle officiel commme s\'il s\'agissait d\'une nouvelle inclusion">Utiliser</a>';
-                    } else if (file_exists($officialP.$id1."/".$id1.".json") ||
-                        file_exists($officialP.$id2."/".$id2.".json")) {
-                        echo '<span style="background-color:red;color:black" title=""> INFO: Modèle officiel disponible.</span>';
-                        // echo '<a class="btn btn-warning" onclick="reinit(\''.$eqId.'\')" title="Réinitlialisation avec le modèle officiel commme s\'il s\'agissait d\'une nouvelle inclusion">Utiliser</a>';
-                    }
-                }
-            } else {
-                if ($jsonLocation != 'Abeille') {
-                    echo '<span style="background-color:red;color:black" title="La configuration vient d\'un fichier local (core/config/devices_local)"> ATTENTION: Issu d\'un modèle local </span>';
-                    if (file_exists(__DIR__."/../../core/config/devices_local/".$jsonId."/".$jsonId.".json"))
-                        echo '<a class="btn btn-warning" onclick="removeLocalJSON(\''.$jsonId.'\')" title="Supprime la version locale du fichier de config JSON">Supprimer version locale</a>';
-                }
-            }
-
-            ?> -->
-            <input id="idModelName" readonly style="width: 200px" title="{{Nom du modèle utilisé}}" value="" />
-            <input id="idModelSource" readonly style="width:86px" title="{{Origine du modèle}}" value="" />
-            <a class="btn btn-warning" id="idUpdateBtn" style="margin-left:8px" title="{{Mise-à-jour à partir de son modèle et reconfiguration}}">{{Mise-à-jour}}</a>
-            <a class="btn btn-danger" id="idReinitBtn" style="margin-left:8px" title="{{Réinitlialise les paramètres par défaut et reconfigure l\'équipement comme s\'il s\'agissait d\'une nouvelle inclusion}}">{{Réinitialiser}}</a>
     </div>
+
+    <!-- Ajout JB Romain 16/08/2023 - Choix du modèle -->
+    <!-- Popup de sélection manuelle du modèle - Contenu masqué, sera ouvert en popup -->
+    <div class="abeille-model-change-popup-content" style="display:none">
+        <h3 style="margin-top:0">{{Choix du modèle d'équipement}}</h3>
+        <p>{{Lors de l'ajout d'un équipement, Abeille identifie automatiquement le modèle à partir de sa signature Zigbee. L'équipement est ensuite automatiquement configuré.}}</p>
+        <p>{{Toutefois, si le modèle identifié n'est pas le bon (rare), ou si votre équipement n'est pas encore connu d'Abeille, vous pouvez forcer ici l'utilisation d'un modèle de votre choix parmi tous les équipements connus.}}</p>
+
+        <p class="alert alert-warning">{{Cette fonction est destinée aux utilisteurs avancés, ne l'utilisez que si vous comprenez parfaitement ce que vous faites.}}</p>
+
+        <p>
+            <label>{{ Modèle actuel de votre équipement: }}</label>
+            <br>
+            <span class='current-model'>-- Aucun --</span>
+        </p>
+
+        <p>
+            <label>{{ Choisissez le modèle à appliquer: }}</label>
+            <br>
+            <input type="search" style="width:100%; box-sizing:border-box" list="abeille-all-models-list" placeholder="{{ Recherchez par fabricant, modèle, ou nom de fichier JSON }}">
+        </p>
+
+        <p style="text-align:center; margin-top:30px">
+            <a class="btn btn-secondary">{{Annuler}}</a>
+            <a class="btn btn-success" title="{{Enregistrer le modèle choisi et reconfigurer l'équipement}}">{{Appliquer le modèle}}</a>
+        </p>
+    </div>
+
+    <!-- Liste de choix des modèles connus d'Abeille, rempli plus tard en ajax, si besoin -->
+    <datalist id="abeille-all-models-list"></datalist>
+    <!-- Fin choix du modèle -->
 </div>
 
-<!-- <div class="form-group">
-    <label class="col-sm-3 control-label">Configuration</label>
-    <div class="col-sm-5">
-        < ?php
-            echo '<a class="btn btn-warning" onclick="update(\''.$eqId.'\')" title="Mise-à-jour à partir de son modèle et reconfiguration">Mise-à-jour</a>';
-            echo '<a class="btn btn-danger" onclick="reinit(\''.$eqId.'\')" style="margin-left:8px" title="Réinitlialise les paramètres par défaut et reconfigure l\'équipement comme s\'il s\'agissait d\'une nouvelle inclusion">Réinitialiser</a>';
-            // Tcharp38: Simplifcation for end users. Moreover no sense to do commands updates without device config since might be closely linked.
-            // echo ' OU ';
-            // echo '<a class="btn btn-warning" onclick="updateFromJSON(\''.$eqNet.'\', \''.$eqAddr.'\')" title="Mets à jour les commandes Jeedom">Recharger</a>';
-            // echo ' ';
-            // echo '<a class="btn btn-warning" onclick="reconfigure(\''.$eqId.'\')" title="Reconfigure l\'équipement">Reconfigurer</a>';
-        ?>
-    </div>
-</div> -->
-
-<!-- < ?php
-    if ($sig) {
-        $path = __DIR__.'/../../core/config/devices_local/'.$sig['modelId'].'_'.$sig['manufId'].'/discovery.json';
-        if (file_exists($path)) {
-?>
-<div class="form-group">
-    <label class="col-sm-3 control-label">'Discovery' local</label>
-    <div class="col-sm-5">
-        < ?php
-        $model = $sig['modelId'];
-        $manuf = $sig['manufId'];
-        echo '<a class="btn btn-success" title="Télécharge le \'discovery.json\' local" onclick="downloadLocalDiscovery(\''.$model.'\', \''.$manuf.'\')"><i class="fas fa-cloud-download-alt"></i> Télécharger</a>';
-        ?>
-    </div>
-</div>
-< ?php } } ?> -->
 
 <div class="form-group">
     <label class="col-sm-3 control-label">{{Assistant de découverte}}</label>
@@ -148,13 +69,6 @@
 <div class="form-group">
     <label class="col-sm-3 control-label">{{Code fabricant (manufCode)}}</label>
     <div class="col-sm-5">
-        <!-- < ?php
-            if (isset($eqZigbee['manufCode']))
-                $manufCode = $eqZigbee['manufCode'];
-            else
-                $manufCode = '';
-            echo '<input readonly title="{{Code fabricant}}" value="'.$manufCode.'" />';
-        ?> -->
         <input id="idManufCode" readonly title="{{Code fabricant}}" value="" />
     </div>
 </div>


### PR DESCRIPTION
Tâche #2611

Donne la possibilité à l'utilisateur de choisir le modèle JSON à utiliser pour un équipement, dans l'onglet Avancé de l'équipement.

Bouton "Choisir manuellement le modèle" ouvre une popup d'explication permet de choisir le modèle JSON à utiliser (parmi ceux natifs et ceux locaux éventuels). La recherche se fait par nom du fabricant, nom du modèle, libellé du type, ou id du JSON:
![image](https://github.com/KiwiHC16/Abeille/assets/72972682/638ed320-ae7f-4720-bca2-834101a3f2d0)

Une fois validé, cela modifie la configuration de l'équipement:
- ab::eqModel (infos du modèle choisi par l'utilisateur)
- ab::isManualModel = true (pour interdire Abeille d'écraser ce choix, voir ci-dessous)

Une fois le modèle enregistré, l'équipement est mis à jour à partir du nouveau modèle, et reconfiguré (l'utilisateur est invité à le réveiller s'il est sur batterie).

Lorsque le modèle a été forcé (ab::isManualModel = true), Abeille ne modifie plus le modèle lorsque l'équipement se réannonce ou lorsque l'utilisateur clique sur "Mise à jour" ou "Réinitialiser". (J'ai juste ajouter des if aux 2 endroits où le modèle était susceptible d'être changé).

Sur l'interface, l'utilisateur voir qu'il utilise un modèle "forcé":
![image](https://github.com/KiwiHC16/Abeille/assets/72972682/b44c1340-67cb-4376-8c15-0c8adfca9e55)

Le lien "Rétablir" supprime la configuration ab::isManualModel = true et invite l'utilisateur à mettre à jour / ré-annoncer l'équipement quand il veut. (Autrement dit le lien "Rétablir" déverrouille uniquement le changement de modèle, l'utilisateur fait ce qu'il veut ensuite.)

J'ai mis un maximum d'explication dans l'interface pour que l'utilisateur comprenne bien ce qu'il fait, et éviter tout besoin de support. 

J'ai fait plein de tests, en principe je n'ai rien cassé.

A propos du code:
J'ai touché:
- le fichier JS principal pour ajouter mes actions
- le template de l'onglet Avancé (desktop\php\Abeille-Eq-Advanced-Device.php) pour ajouter le bouton et la popup
- nouveau fichier core\ajax\AbeilleModelChange.ajax.php pour les actions ajax (plus propre que de tout mettre dans le même gros fichier)
- A la marge, core\class\Abeille.class.php et core\ajax\Abeille.ajax.php pour ajouter les if(! isManualModel)

Il est possible que mon IDE (VScode) ait corrigé l'indentation dans ces fichiers, mais très peu de vraie modif.

A ta dispo pour échanger.

Jean-Baptiste