### PR TITLE
Fix model forced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+# VSCODE IDE settings
+.vscode/
+
 **/Thumbs.db
 **/COMchmod
 ._*

--- a/core/ajax/Abeille.ajax.php
+++ b/core/ajax/Abeille.ajax.php
@@ -572,7 +572,7 @@
                 $eq['modelName'] = isset($model['id']) ? $model['id'] : '';
                 $eq['modelSource'] = isset($model['location']) ? $model['location'] : 'Abeille';
                 $eq['modelType'] = isset($model['type']) ? $model['type'] : '';
-                $eq['modelForced'] = isset($model['forcedByUser']) ? $model['forcedByUser'] : '';
+                $eq['modelForced'] = isset($model['forcedByUser']) ? $model['forcedByUser'] : false;
 
                 $eq['zigbee'] = $eqLogic->getConfiguration('ab::zigbee', []);
 

--- a/core/php/AbeilleRepair.php
+++ b/core/php/AbeilleRepair.php
@@ -167,6 +167,7 @@
         //     'id' =>
         //     'location' =>
         //     'type' =>
+        //     'forcedByUser' => true|false
         // )
         $model = $eqLogic->getConfiguration('ab::eqModel', []);
         logMessage('debug', '  ab::eqModel='.json_encode($model));
@@ -177,6 +178,7 @@
                 $model['id'] = $m['jsonId'];
                 $model['location'] = $m['location'];
                 $model['type'] = $m['type'];
+                $model['forcedByUser'] = false;
                 $eqLogic->setConfiguration('ab::eqModel', $model);
                 $eqLogic->save();
                 logMessage('debug', "  ab::eqModel updated to ".json_encode($model));
@@ -184,6 +186,7 @@
                 $model['id'] = 'defaultUnknown';
                 $model['location'] = 'Abeille';
                 $model['type'] = 'Unknown device';
+                $model['forcedByUser'] = false;
                 $eqLogic->setConfiguration('ab::eqModel', $model);
                 $eqLogic->save();
                 logMessage('debug', "  ab::eqModel updated to ".json_encode($model));


### PR DESCRIPTION
Hello,

Correction de la fonctionnalité de forçage manuel de l'équipement par l'utilisateur:
- Perte de l'info de forçage suite au renommage de la variable de configuration (dans ab::eqModel au lieu d'être à la racine): corrigé
- Code commenté en anglais conformément à l'usage dans Abeille

Mineur: ajout de la configuration de l'IDE VSCODE au .gitignore

Remarques: 
- plusieurs fichiers changés, mais cette fois normalement le contrôle devrait être plus simple (car j'ai désactivé le formatage automatique des sources)
- testé à fond et dans tous les sens: sûr à 99+% que la fonctionnalité est OK et ne casse rien
- il faudrait pousser en bêta sans trop tarder si possible: la fonction est cassée dans la bêta actuelle (suite au renommage de la configuration qui n'était pas faite partout).

A ta dispo si tu as des questions/remarques.

Jean-Baptiste